### PR TITLE
Symlink patch & CICE netcdf4 parrallel

### DIFF
--- a/archive_cice_restarts.sh
+++ b/archive_cice_restarts.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# clean up cice_restarts.sh
+
+if [ -f archive/output*/GMOM_JRA.cice.r.* ] 
+then
+rm archive/output*/GMOM_JRA.cice.r.*
+fi
+
+if [ -f archive/output*/input/iced.1900-01-01-10800.nc ] 
+then
+rm archive/output*/input/iced.1900-01-01-10800.nc
+fi

--- a/config.yaml
+++ b/config.yaml
@@ -29,6 +29,10 @@ input:
 collate: false
 runlog: false
 
+userscripts:
+    setup: ./setup_cice_restarts.sh
+    archive: ./archive_cice_restarts.sh
+
 modules:
   use:
       - /g/data/ik11/spack/0.20.1/modules/access-om3/0.x.0/linux-rocky8-cascadelake

--- a/ice_in
+++ b/ice_in
@@ -7,8 +7,9 @@
   dumpfreq = "y"
   dump_last = .true.
   histfreq = "d", "m", "x", "x", "x"
+  history_precision = 8
   ice_ic = "./input/iced.1900-01-01-10800.nc"
-  lcdf64 = .true.
+  lcdf64 = .false.
   npt = 35040
   pointer_file      = './rpointer.ice'
   print_global      = .false.

--- a/nuopc.runconfig
+++ b/nuopc.runconfig
@@ -288,13 +288,13 @@ CLOCK_attributes::
      lnd_cpl_dt = 3600
      ocn_cpl_dt = 3600
      restart_n = 1
-     restart_option = nmonths
+     restart_option = ndays
      restart_ymd = -999
      rof_cpl_dt = 3600
      start_tod = 0
      start_ymd = 00010101
      stop_n = 1
-     stop_option = nmonths
+     stop_option = ndays
      stop_tod = 0
      stop_ymd = -999
      tprof_n = -999
@@ -376,12 +376,12 @@ ICE_modelio::
      diro = ./log
      logfile = ice.log
      pio_async_interface = .false.
-     pio_netcdf_format = 64bit_offset
-     pio_numiotasks = -99
-     pio_rearranger = 2
-     pio_root = 1
+     pio_netcdf_format = nothing
+     pio_numiotasks = 1
+     pio_rearranger = 1
+     pio_root = 0
      pio_stride = 48
-     pio_typename = netcdf
+     pio_typename = netcdf4p
 ::
 
 OCN_modelio::

--- a/nuopc.runconfig
+++ b/nuopc.runconfig
@@ -288,13 +288,13 @@ CLOCK_attributes::
      lnd_cpl_dt = 3600
      ocn_cpl_dt = 3600
      restart_n = 1
-     restart_option = ndays
+     restart_option = nmonths
      restart_ymd = -999
      rof_cpl_dt = 3600
      start_tod = 0
      start_ymd = 00010101
      stop_n = 1
-     stop_option = ndays
+     stop_option = nmonths
      stop_tod = 0
      stop_ymd = -999
      tprof_n = -999

--- a/setup_cice_restarts.sh
+++ b/setup_cice_restarts.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# patch for https://github.com/open-mpi/ompi/issues/12141
+if ! [ -f work/GMOM_JRA.cice.r.* ] 
+then 
+# no restart files yet, use initial conditions
+IC=$(readlink work/input/iced.1900-01-01-10800.nc)
+rm work/input/iced.1900-01-01-10800.nc
+cp $IC work/input/iced.1900-01-01-10800.nc
+else
+# change restart symlink to hardlink
+RESTART=$(echo work/GMOM_JRA.cice.r.*)
+ln -f $(readlink $RESTART) $RESTART
+fi


### PR DESCRIPTION
As part of https://github.com/COSIMA/access-om3/issues/81, it was identified that there is a bug with symlink handling with parallel reads in openmpi (https://github.com/open-mpi/ompi/issues/12141). The fix for the bug will be included in OpenMpi 4.1.7 but this may not be released until end of March 2024. This bug blocks use of netcdf4 in CICE.

In the interim, we can patch this bug using the two scripts in this PR, which replace the symlink to the initial conditions with a copy of the initial conditions file and replace the symlink to restart files with a hardlink to restart files. (We can't rely on hardlinking to the initial conditions file because it may not be on the same file system as where the model is being run from.)

This allows turning on netcdf4 support in CICE (in nuopc.runconfig).

In the current config, reported ReadWrite time for one month is 50-60seconds. With this change, reported times are ~13 seconds. And this corresponds to a similar change in total time (150 to 110 seconds).