### PR TITLE
limit valid years to 1958 to 2018

### DIFF
--- a/datm.streams.xml
+++ b/datm.streams.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <file id="stream" version="2.0">
   <stream_info name="CORE_IAF_JRA55do.PRSN">
-    <taxmode>cycle</taxmode>
+    <taxmode>limit</taxmode>
     <readmode>single</readmode>
     <mapalgo>bilinear</mapalgo>
     <dtlimit>1.5</dtlimit>
@@ -81,7 +81,7 @@
     <tintalgo>linear</tintalgo>
   </stream_info>
   <stream_info name="CORE_IAF_JRA55do.PRRN">
-    <taxmode>cycle</taxmode>
+    <taxmode>limit</taxmode>
     <readmode>single</readmode>
     <mapalgo>bilinear</mapalgo>
     <dtlimit>1.5</dtlimit>
@@ -161,7 +161,7 @@
     <tintalgo>linear</tintalgo>
   </stream_info>
   <stream_info name="CORE_IAF_JRA55do.LWDN">
-    <taxmode>cycle</taxmode>
+    <taxmode>limit</taxmode>
     <readmode>single</readmode>
     <mapalgo>bilinear</mapalgo>
     <dtlimit>1.5</dtlimit>
@@ -241,7 +241,7 @@
     <tintalgo>linear</tintalgo>
   </stream_info>
   <stream_info name="CORE_IAF_JRA55do.SWDN">
-    <taxmode>cycle</taxmode>
+    <taxmode>limit</taxmode>
     <readmode>single</readmode>
     <mapalgo>bilinear</mapalgo>
     <dtlimit>1.5</dtlimit>
@@ -321,7 +321,7 @@
     <tintalgo>coszen</tintalgo>
   </stream_info>
   <stream_info name="CORE_IAF_JRA55do.Q_10">
-    <taxmode>cycle</taxmode>
+    <taxmode>limit</taxmode>
     <readmode>single</readmode>
     <mapalgo>bilinear</mapalgo>
     <dtlimit>1.5</dtlimit>
@@ -401,7 +401,7 @@
     <tintalgo>linear</tintalgo>
   </stream_info>
   <stream_info name="CORE_IAF_JRA55do.SLP_10">
-    <taxmode>cycle</taxmode>
+    <taxmode>limit</taxmode>
     <readmode>single</readmode>
     <mapalgo>bilinear</mapalgo>
     <dtlimit>1.5</dtlimit>
@@ -481,7 +481,7 @@
     <tintalgo>linear</tintalgo>
   </stream_info>
   <stream_info name="CORE_IAF_JRA55do.T_10">
-    <taxmode>cycle</taxmode>
+    <taxmode>limit</taxmode>
     <readmode>single</readmode>
     <mapalgo>bilinear</mapalgo>
     <dtlimit>1.5</dtlimit>
@@ -561,7 +561,7 @@
     <tintalgo>linear</tintalgo>
   </stream_info>
   <stream_info name="CORE_IAF_JRA55do.U_10">
-    <taxmode>cycle</taxmode>
+    <taxmode>limit</taxmode>
     <readmode>single</readmode>
     <mapalgo>bilinear</mapalgo>
     <dtlimit>1.5</dtlimit>
@@ -641,7 +641,7 @@
     <tintalgo>linear</tintalgo>
   </stream_info>
   <stream_info name="CORE_IAF_JRA55do.V_10">
-    <taxmode>cycle</taxmode>
+    <taxmode>limit</taxmode>
     <readmode>single</readmode>
     <mapalgo>bilinear</mapalgo>
     <dtlimit>1.5</dtlimit>

--- a/drof.streams.xml
+++ b/drof.streams.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <file id="stream" version="2.0">
   <stream_info name="rof.iaf_jra">
-    <taxmode>cycle</taxmode>
+    <taxmode>limit</taxmode>
     <tintalgo>upper</tintalgo>
     <readmode>single</readmode>
     <mapalgo>bilinear</mapalgo>
@@ -81,7 +81,7 @@
     <offset>-43200</offset>
   </stream_info>
   <stream_info name="rof.iaf_jra">
-    <taxmode>cycle</taxmode>
+    <taxmode>limit</taxmode>
     <tintalgo>upper</tintalgo>
     <readmode>single</readmode>
     <mapalgo>bilinear</mapalgo>

--- a/generate_xml_datm.py
+++ b/generate_xml_datm.py
@@ -4,9 +4,7 @@
 
 # Contact: Ezhilsabareesh Kannadasan
 # To run:
-#   python generate_xml_datm.py <year_first> <year_last> 
-# To generate RYF xml file, set year_first == year_last. The value of year_align has no
-# effect
+#   python generate_xml_datm.py <year_first> <year_last> <year_align>
 # To generate IAF xml file, set year_first and year_last to the forcing period and
 # year_align == year_first
 
@@ -57,7 +55,7 @@ var_names = {
 # Generate stream info elements with changing years
 for stream_name in stream_info_names:
     stream_info = SubElement(root, "stream_info", name=stream_name)
-    SubElement(stream_info, "taxmode").text = "cycle"
+    SubElement(stream_info, "taxmode").text = "limit"
     SubElement(stream_info, "readmode").text = "single"
     SubElement(stream_info, "mapalgo").text = "bilinear"
     SubElement(stream_info, "dtlimit").text = "1.5"

--- a/generate_xml_drof.py
+++ b/generate_xml_drof.py
@@ -4,9 +4,7 @@
 
 # Contact: Ezhilsabareesh Kannadasan
 # To run:
-#   python generate_xml_drof.py <year_first> <year_last> 
-# To generate RYF xml file, set year_first == year_last. The value of year_align has no
-# effect
+#   python generate_xml_drof.py <year_first> <year_last> <year_align>
 # To generate IAF xml file, set year_first and year_last to the forcing period and
 # year_align == year_first
 
@@ -38,7 +36,7 @@ stream_info_data = [
 # Generate stream info elements with changing years
 for stream_name, var_prefix, var_suffix in stream_info_data:
     stream_info = SubElement(root, "stream_info", name=stream_name)
-    SubElement(stream_info, "taxmode").text = "cycle"
+    SubElement(stream_info, "taxmode").text = "limit"
     SubElement(stream_info, "tintalgo").text = "upper"
     SubElement(stream_info, "readmode").text = "single"
     SubElement(stream_info, "mapalgo").text = "bilinear"

--- a/generate_xml_drof.py
+++ b/generate_xml_drof.py
@@ -4,25 +4,26 @@
 
 # Contact: Ezhilsabareesh Kannadasan
 # To run:
-#   python generate_xml_drof.py <year_first> <year_last> <year_align>
-# To generate IAF xml file, set year_first and year_last to the forcing period and
-# year_align == year_first
+#   python generate_xml_datm.py <year_first> <year_last>
+# To generate IAF xml file, set year_first and year_last to the forcing period
+# To generate RYF xml file, set year_first==year_last
 
 from xml.etree.ElementTree import Element, SubElement, tostring
 from xml.dom import minidom
 import sys
 
-if len(sys.argv) != 4:
+if len(sys.argv) != 3:
     print("Usage: python generate_xml_drof.py year_first year_last year_align")
     sys.exit(1)
 
 try:
     year_first = int(sys.argv[1])
     year_last = int(sys.argv[2])
-    year_align = int(sys.argv[3])
 except ValueError:
     print("Year values must be integers")
     sys.exit(1)
+
+year_align = year_first
 
 # Create the root element
 root = Element("file", id="stream", version="2.0")
@@ -36,7 +37,10 @@ stream_info_data = [
 # Generate stream info elements with changing years
 for stream_name, var_prefix, var_suffix in stream_info_data:
     stream_info = SubElement(root, "stream_info", name=stream_name)
-    SubElement(stream_info, "taxmode").text = "limit"
+    if year_first == year_last:
+        SubElement(stream_info, "taxmode").text = "cycle"
+    else:
+        SubElement(stream_info, "taxmode").text = "limit"
     SubElement(stream_info, "tintalgo").text = "upper"
     SubElement(stream_info, "readmode").text = "single"
     SubElement(stream_info, "mapalgo").text = "bilinear"
@@ -50,19 +54,20 @@ for stream_name, var_prefix, var_suffix in stream_info_data:
 
     datafiles = SubElement(stream_info, "datafiles")
     datavars = SubElement(stream_info, "datavars")
-    SubElement(stream_info, "offset").text = "-43200"  # shift backwards from noon to midnight to match RYF
+    SubElement(
+        stream_info, "offset"
+    ).text = "-43200"  # shift backwards from noon to midnight to match RYF
 
     var_element = SubElement(datavars, "var")
     var_element.text = f"{var_prefix} {var_suffix}"
 
     for year in range(year_first, year_last + 1):
-
         if year_first == year_last:
             file_element = SubElement(datafiles, "file")
             file_element.text = f"./input/RYF.{var_prefix}.{year+90}_{year + 90 + 1}.nc"
         else:
             file_element = SubElement(datafiles, "file")
-            if var_prefix  == "friver":
+            if var_prefix == "friver":
                 if year != 2019:
                     file_element.text = f"./input/land/day/{var_prefix}/gr/v20190429/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_{year}0101-{year}1231.nc"
                 else:
@@ -79,4 +84,3 @@ xml_str = minidom.parseString(tostring(root)).toprettyxml(indent="  ")
 # Write the XML content to a file
 with open("drof.streams.xml", "w") as xml_file:
     xml_file.write(xml_str)
-


### PR DESCRIPTION
Turn off cycling around forcing data for iaf runs. #22 