### PR TITLE
1deg_jra55do_iaf: update OM3 executable to latest version

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -32,11 +32,3 @@ runlog: false
 userscripts:
     setup: ./setup_cice_restarts.sh
     archive: ./archive_cice_restarts.sh
-
-modules:
-  use:
-      - /g/data/ik11/spack/0.20.1/modules/access-om3/0.x.0/linux-rocky8-cascadelake
-  load:
-      - intel-compiler/2021.6.0
-      - openmpi/4.1.4
-      - parallelio/2.5.10

--- a/config.yaml
+++ b/config.yaml
@@ -18,7 +18,7 @@ jobname: 1deg_jra55do_iaf
 
 model: access-om3
 
-exe: /g/data/ik11/spack/0.20.1/opt/linux-rocky8-cascadelake/intel-2021.6.0/access-om3-main-lxbeca7/bin/access-om3-MOM6-CICE6
+exe: /g/data/ik11/spack/0.21.2/opt/linux-rocky8-cascadelake/intel-2021.10.0/access-om3-main-6pue372/bin/access-om3-MOM6-CICE6
 input: 
     - /g/data/ik11/inputs/access-om3/0.x.0/1deg/share # shared grids and topography
     - /g/data/ik11/inputs/access-om3/0.x.0/1deg/mom # grids, ICs etc

--- a/fd.yaml
+++ b/fd.yaml
@@ -487,6 +487,18 @@
        canonical_units: m
        description: atmosphere import
      #
+     - standard_name: So_ugustOut
+       canonical_units: m/s
+       description: atmosphere import
+     #
+     - standard_name: So_u10withGust
+       canonical_units: m/s
+       description: atmosphere import
+     #
+     - standard_name: So_u10res
+       canonical_units: m/s
+       description: atmosphere import
+     #
      #-----------------------------------
      # section: land-ice export
      # Note that the fields sent from glc->med do NOT have elevation classes,

--- a/manifests/exe.yaml
+++ b/manifests/exe.yaml
@@ -2,7 +2,7 @@ format: yamanifest
 version: 1.0
 ---
 work/access-om3-MOM6-CICE6:
-  fullpath: /g/data/ik11/spack/0.20.1/opt/linux-rocky8-cascadelake/intel-2021.6.0/access-om3-main-lxbeca7/bin/access-om3-MOM6-CICE6
+  fullpath: /g/data/ik11/spack/0.21.2/opt/linux-rocky8-cascadelake/intel-2021.10.0/access-om3-main-6pue372/bin/access-om3-MOM6-CICE6
   hashes:
-    binhash: e9a7281fa7602ea36407c1a6a6406764
-    md5: 507f2fad9c41ae46eca4145c180cda37
+    binhash: f28129ea2dfe30a3b48932b40b40b9ab
+    md5: 2889850d155a1986dabfbc443dcb4eb7


### PR DESCRIPTION
Changes needed to use latest OM3 executable.

Contributes to https://github.com/COSIMA/access-om3/issues/118