### PR TITLE
CICE config for CICE6.5

### DIFF
--- a/MOM_input
+++ b/MOM_input
@@ -408,6 +408,12 @@ RESTART_CONTROL = 3
                                 ! restart file is saved at the end of the run segment
                                 ! for any non-negative value."
 
+EPS_OMESH = 1e-13
+                                ! "default = 0.0001
+                                ! An float which sets the allowable error (in degrees) between
+                                ! grid angle defined in the ESMF mesh file used by CMEPS
+                                ! and the ocean_hgrid file used by mom
+
 ! === module MOM_tracer_flow_control ===
 USE_IDEAL_AGE_TRACER = True
                                 ! "[Boolean] default = False

--- a/config.yaml
+++ b/config.yaml
@@ -44,6 +44,8 @@ input:
  
 collate: false
 runlog: false
+metadata: 
+    enable: false
 
 userscripts:
     setup: ./setup_cice_restarts.sh

--- a/config.yaml
+++ b/config.yaml
@@ -27,8 +27,8 @@ input:
     - /g/data/vk83/experiments/inputs/access-om3/mom/grids/vertical/global.1deg/2023.07.28/ocean_vgrid.nc
     - /g/data/vk83/experiments/inputs/access-om3/mom/initial_conditions/global.1deg/2020.10.22/ocean_temp_salt.res.nc
     - /g/data/vk83/experiments/inputs/access-om3/mom/surface_salt_restoring/global.1deg/2020.05.30/salt_sfc_restore.nc
-    - /g/data/vk83/experiments/inputs/access-om3/cice/grids/global.1deg/2020.05.30/grid.nc
-    - /g/data/vk83/experiments/inputs/access-om3/cice/grids/global.1deg/2020.10.22/kmt.nc
+    - /g/data/vk83/experiments/inputs/access-om3/cice/grids/global.1deg/2024.05.14/grid.nc
+    - /g/data/vk83/experiments/inputs/access-om3/cice/grids/global.1deg/2024.05.14/kmt.nc
     - /g/data/vk83/experiments/inputs/access-om3/cice/initial_conditions/global.1deg/2023.07.28/iced.1900-01-01-10800.nc
     - /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prsn/gr/v20190429
     - /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prra/gr/v20190429

--- a/ice_in
+++ b/ice_in
@@ -127,6 +127,10 @@
   !-----------------------------------
   ! These fields are on by default (in ice_history_shared.F90) but lets turn them off
   !-----------------------------------
+  f_tlon         = .false. , f_tlat         = .false.
+  f_ulon         = .false. ,  f_ulat         = .false.
+  f_nlon         = .false. ,  f_nlat         = .false.
+  f_elon         = .false. ,  f_elat         = .false.
   f_albpnd = 'x'
   f_atmdir = 'x' , f_atmspd = 'x'
   f_coszen = 'x'

--- a/ice_in
+++ b/ice_in
@@ -7,6 +7,7 @@
   histfreq = "d", "m", "x", "x", "x"
   hist_time_axis = "middle"
   history_deflate = 1
+  history_chunksize = 180, 150
   history_precision = 8
   restart_deflate = 1
   ice_ic = "./input/iced.1900-01-01-10800.nc"

--- a/ice_in
+++ b/ice_in
@@ -1,8 +1,6 @@
 &setup_nml
   bfbflag = "off" 
   conserv_check = .false.
-  debug_forcing = .true.
-  debug_model = .true.
   diagfreq = 960
   dumpfreq = "y"
   dump_last = .true.

--- a/ice_in
+++ b/ice_in
@@ -125,6 +125,7 @@
   f_fsurfn_ai = "m"
   f_hi = "md"
   f_hs = "md"
+  f_sifb = "md"
   f_snoice = "md"
   f_uvel = "md" , f_vvel = "md"
   f_vicen = "m"

--- a/ice_in
+++ b/ice_in
@@ -131,6 +131,21 @@
   f_ulon         = .false. ,  f_ulat         = .false.
   f_nlon         = .false. ,  f_nlat         = .false.
   f_elon         = .false. ,  f_elat         = .false.
+  f_umask        = .false.
+  f_nmask        = .false.
+  f_emask        = .false.
+  f_narea        = .false.
+  f_earea        = .false.
+  f_dxt          = .false.
+  f_dyt          = .false.
+  f_dxu          = .false.
+  f_dyu          = .false.
+  f_dxe          = .false.
+  f_dye          = .false.
+  f_dxn          = .false.
+  f_dyn          = .false.
+  f_HTN          = .false.
+  f_HTE          = .false.
   f_albpnd = 'x'
   f_atmdir = 'x' , f_atmspd = 'x'
   f_coszen = 'x'

--- a/ice_in
+++ b/ice_in
@@ -13,7 +13,6 @@
   npt = 35040
   pointer_file = './rpointer.ice'
   print_global = .false.
-  use_leap_years = .true.
 /
 &grid_nml
   bathymetry_file = "./input/topog.nc"

--- a/ice_in
+++ b/ice_in
@@ -5,6 +5,7 @@
   dumpfreq = "y"
   dump_last = .true.
   histfreq = "d", "m", "x", "x", "x"
+  hist_time_axis = "middle"
   history_precision = 8
   ice_ic = "./input/iced.1900-01-01-10800.nc"
   lcdf64 = .false.
@@ -128,24 +129,18 @@
   ! These fields are on by default (in ice_history_shared.F90) but lets turn them off
   !-----------------------------------
   f_tlon         = .false. , f_tlat         = .false.
-  f_ulon         = .false. ,  f_ulat         = .false.
-  f_nlon         = .false. ,  f_nlat         = .false.
-  f_elon         = .false. ,  f_elat         = .false.
-  f_umask        = .false.
-  f_nmask        = .false.
-  f_emask        = .false.
-  f_narea        = .false.
-  f_earea        = .false.
-  f_dxt          = .false.
-  f_dyt          = .false.
-  f_dxu          = .false.
-  f_dyu          = .false.
-  f_dxe          = .false.
-  f_dye          = .false.
-  f_dxn          = .false.
-  f_dyn          = .false.
-  f_HTN          = .false.
-  f_HTE          = .false.
+  f_ulon         = .false. , f_ulat         = .false.
+  f_nlon         = .false. , f_nlat         = .false.
+  f_elon         = .false. , f_elat         = .false.
+  f_tmask        = .false. , f_umask        = .false.
+  f_nmask        = .false. , f_emask        = .false.
+  f_tarea        = .false. , f_uarea        = .false.
+  f_narea        = .false. , f_earea        = .false.
+  f_dxt          = .false. , f_dyt          = .false.
+  f_dxu          = .false. , f_dyu          = .false.
+  f_dxe          = .false. , f_dye          = .false.
+  f_dxn          = .false. , f_dyn          = .false.
+  f_HTN          = .false. , f_HTE          = .false.
   f_albpnd = 'x'
   f_atmdir = 'x' , f_atmspd = 'x'
   f_coszen = 'x'

--- a/ice_in
+++ b/ice_in
@@ -6,7 +6,9 @@
   dump_last = .true.
   histfreq = "d", "m", "x", "x", "x"
   hist_time_axis = "middle"
+  history_deflate = 1
   history_precision = 8
+  restart_deflate = 1
   ice_ic = "./input/iced.1900-01-01-10800.nc"
   lcdf64 = .false.
   npt = 35040

--- a/manifests/input.yaml
+++ b/manifests/input.yaml
@@ -327,10 +327,10 @@ work/input/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_2019010
     binhash: 36d7f4b4cd4d038da099b444d984d0b0
     md5: 8cdb2421fa7056bc3c07577005071f71
 work/input/grid.nc:
-  fullpath: /g/data/vk83/experiments/inputs/access-om3/cice/grids/global.1deg/2020.05.30/grid.nc
+  fullpath: /g/data/vk83/experiments/inputs/access-om3/cice/grids/global.1deg/2024.05.14/grid.nc
   hashes:
-    binhash: c7cb377ba3a6b159b625b5fa3b6ea377
-    md5: 1213e346055ee073fe33dc12578d99c6
+    binhash: 60ac2869d4521fd6441a90b519d9bce0
+    md5: 544a40b634c182f3e182da6bcbe8be7b
 work/input/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_195801010000-195812312100.nc:
   fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/huss/gr/v20190429/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_195801010000-195812312100.nc
   hashes:
@@ -647,10 +647,10 @@ work/input/iced.1900-01-01-10800.nc:
     binhash: a88d7f33c7eef8f6870773f7cc47fc28
     md5: 87c012d60c58c65bb56caa98779e5e51
 work/input/kmt.nc:
-  fullpath: /g/data/vk83/experiments/inputs/access-om3/cice/grids/global.1deg/2020.10.22/kmt.nc
+  fullpath: /g/data/vk83/experiments/inputs/access-om3/cice/grids/global.1deg/2024.05.14/kmt.nc
   hashes:
-    binhash: 0c0a298f90d40f05cf1893efbc2b8083
-    md5: 1f9806c646a620378e5257e480bc9df7
+    binhash: 6fd7a86039ea089fffc371390c14d77a
+    md5: 4dae75252ac93467f10ea26e833e13d2
 work/input/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19580101-19581231.nc:
   fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/landIce/day/licalvf/gr/v20190429/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19580101-19581231.nc
   hashes:

--- a/nuopc.runconfig
+++ b/nuopc.runconfig
@@ -311,6 +311,7 @@ ATM_attributes::
 ::
 
 ICE_attributes::
+     eps_imesh = 1e-13 # allowed error between angles in mesh file and cice grid
      Verbosity = off
 ::
 


### PR DESCRIPTION
Changes described in https://github.com/COSIMA/access-om3/issues/113 for move to CICE 6.5. Uncompressed daily history output is 15MB, compressed is 2MB.

Add new cice grid from https://github.com/COSIMA/esmgrids/pull/6 and (https://github.com/COSIMA/access-om2/issues/279 )

Tigthen grid angle check limits (per https://github.com/COSIMA/access-om3/issues/144)

Add freeboard as a default history output to make validation easier.

Turn off metadata for development work.

Change should be described in each commit, I will not squash the commits.