### PR TITLE
Meaningless values for {model_name}_cpl_dt in nuopc.runconfig 1deg_jra55do_ryf

### DIFF
--- a/nuopc.runconfig
+++ b/nuopc.runconfig
@@ -278,19 +278,19 @@ MED_attributes::
 ::
 
 CLOCK_attributes::
-     atm_cpl_dt = 3600
+     atm_cpl_dt = 99999
      calendar = NO_LEAP
      end_restart = .false.
      glc_avg_period = yearly
      glc_cpl_dt = 86400
      history_ymd = -999
-     ice_cpl_dt = 3600
-     lnd_cpl_dt = 3600
-     ocn_cpl_dt = 3600
+     ice_cpl_dt =  99999
+     lnd_cpl_dt =  99999
+     ocn_cpl_dt =  99999
      restart_n = 1
      restart_option = nmonths
      restart_ymd = -999
-     rof_cpl_dt = 3600
+     rof_cpl_dt =  99999
      start_tod = 0
      start_ymd = 19000101
      stop_n = 1
@@ -300,7 +300,7 @@ CLOCK_attributes::
      tprof_n = -999
      tprof_option = never
      tprof_ymd = -999
-     wav_cpl_dt = 3600
+     wav_cpl_dt = 99999
 ::
 
 ATM_attributes::

--- a/nuopc.runconfig
+++ b/nuopc.runconfig
@@ -278,19 +278,19 @@ MED_attributes::
 ::
 
 CLOCK_attributes::
-     atm_cpl_dt = 99999
+     atm_cpl_dt = 99999       #not used
      calendar = NO_LEAP
      end_restart = .false.
      glc_avg_period = yearly
      glc_cpl_dt = 86400
      history_ymd = -999
-     ice_cpl_dt =  99999
-     lnd_cpl_dt =  99999
-     ocn_cpl_dt =  99999
+     ice_cpl_dt =  99999      #not used
+     lnd_cpl_dt =  99999      #not used
+     ocn_cpl_dt =  99999      #not used
      restart_n = 1
      restart_option = nmonths
      restart_ymd = -999
-     rof_cpl_dt =  99999
+     rof_cpl_dt =  99999      #not used
      start_tod = 0
      start_ymd = 19000101
      stop_n = 1
@@ -300,7 +300,7 @@ CLOCK_attributes::
      tprof_n = -999
      tprof_option = never
      tprof_ymd = -999
-     wav_cpl_dt = 99999
+     wav_cpl_dt = 99999       #not used
 ::
 
 ATM_attributes::

--- a/nuopc.runconfig
+++ b/nuopc.runconfig
@@ -278,19 +278,19 @@ MED_attributes::
 ::
 
 CLOCK_attributes::
-     atm_cpl_dt = 99999       #not used
+     atm_cpl_dt = 99999 #not used
      calendar = NO_LEAP
      end_restart = .false.
      glc_avg_period = yearly
      glc_cpl_dt = 86400
      history_ymd = -999
-     ice_cpl_dt =  99999      #not used
-     lnd_cpl_dt =  99999      #not used
-     ocn_cpl_dt =  99999      #not used
+     ice_cpl_dt =  99999 #not used
+     lnd_cpl_dt =  99999 #not used
+     ocn_cpl_dt =  3600
      restart_n = 1
      restart_option = nmonths
      restart_ymd = -999
-     rof_cpl_dt =  99999      #not used
+     rof_cpl_dt =  99999 #not used
      start_tod = 0
      start_ymd = 19000101
      stop_n = 1

--- a/nuopc.runconfig
+++ b/nuopc.runconfig
@@ -282,15 +282,15 @@ CLOCK_attributes::
      calendar = NO_LEAP
      end_restart = .false.
      glc_avg_period = yearly
-     glc_cpl_dt = 86400
+     glc_cpl_dt = 99999 #not used
      history_ymd = -999
-     ice_cpl_dt =  99999 #not used
-     lnd_cpl_dt =  99999 #not used
+     ice_cpl_dt = 99999 #not used
+     lnd_cpl_dt = 99999 #not used
      ocn_cpl_dt =  3600
      restart_n = 1
      restart_option = nmonths
      restart_ymd = -999
-     rof_cpl_dt =  99999 #not used
+     rof_cpl_dt = 99999 #not used
      start_tod = 0
      start_ymd = 19000101
      stop_n = 1
@@ -300,7 +300,7 @@ CLOCK_attributes::
      tprof_n = -999
      tprof_option = never
      tprof_ymd = -999
-     wav_cpl_dt = 99999       #not used
+     wav_cpl_dt = 99999 #not used
 ::
 
 ATM_attributes::


### PR DESCRIPTION
This PR address [#132](https://github.com/COSIMA/access-om3/issues/132) by setting meaningless values for `{model_name}_cpl_dt` in nuopc.runconfig .