### PR TITLE
1deg_jra55do_iaf: Update OM3 executable to latest version

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -17,8 +17,7 @@ walltime: 01:00:00
 jobname: 1deg_jra55do_iaf
 
 model: access-om3
-
-exe: /g/data/ik11/spack/0.21.2/opt/linux-rocky8-cascadelake/intel-2021.10.0/access-om3-main-6pue372/bin/access-om3-MOM6-CICE6
+exe: /g/data/ik11/spack/0.21.2/opt/linux-rocky8-cascadelake/intel-2021.10.0/access-om3-d6813d6b9e1df560ac3f6ba6a605daab9cfd9569_main-5pjh7z2/bin/access-om3-MOM6-CICE6
 input: 
     - /g/data/ik11/inputs/access-om3/0.x.0/1deg/share # shared grids and topography
     - /g/data/ik11/inputs/access-om3/0.x.0/1deg/mom # grids, ICs etc

--- a/manifests/exe.yaml
+++ b/manifests/exe.yaml
@@ -2,7 +2,7 @@ format: yamanifest
 version: 1.0
 ---
 work/access-om3-MOM6-CICE6:
-  fullpath: /g/data/ik11/spack/0.21.2/opt/linux-rocky8-cascadelake/intel-2021.10.0/access-om3-main-6pue372/bin/access-om3-MOM6-CICE6
+  fullpath: /g/data/ik11/spack/0.21.2/opt/linux-rocky8-cascadelake/intel-2021.10.0/access-om3-d6813d6b9e1df560ac3f6ba6a605daab9cfd9569_main-5pjh7z2/bin/access-om3-MOM6-CICE6
   hashes:
-    binhash: f28129ea2dfe30a3b48932b40b40b9ab
-    md5: 2889850d155a1986dabfbc443dcb4eb7
+    binhash: 4b05dc495b4fe5ce2e71fa9a7ff62f72
+    md5: ba3b677b7c386c09e6430617c26cab58


### PR DESCRIPTION
This implements a new naming scheme for the exec path.

Contributes to https://github.com/COSIMA/access-om3/issues/118