### PR TITLE
025deg jra55do ryf.iss113

### DIFF
--- a/MOM_input
+++ b/MOM_input
@@ -141,6 +141,12 @@ DTFREEZE_DP = -7.75E-08         !   [deg C Pa-1] default = 0.0
                                 ! When TFREEZE_FORM=LINEAR, this is the derivative of the freezing potential
                                 ! temperature with pressure.
 
+EPS_OMESH = 1e-13
+                                ! "default = 0.0001
+                                ! An float which sets the allowable error (in degrees) between
+                                ! grid angle defined in the ESMF mesh file used by CMEPS
+                                ! and the ocean_hgrid file used by mom
+
 ! === module MOM_tracer_flow_control ===
 USE_IDEAL_AGE_TRACER = True     !   [Boolean] default = False
                                 ! If true, use the ideal_age_example tracer package.

--- a/config.yaml
+++ b/config.yaml
@@ -34,6 +34,8 @@ input:
  
 collate: false
 runlog: false
+metadata: 
+    enable: false
 
 userscripts:
     setup: ./setup_cice_restarts.sh

--- a/config.yaml
+++ b/config.yaml
@@ -28,8 +28,8 @@ input:
     - /g/data/vk83/experiments/inputs/access-om3/mom/grids/vertical/global.025deg/2024.04.04/ocean_vgrid.nc
     - /g/data/vk83/experiments/inputs/access-om3/mom/initial_conditions/global.025deg/2020.10.22/ocean_temp_salt.res.nc
     - /g/data/vk83/experiments/inputs/access-om3/mom/surface_salt_restoring/global.025deg/2020.05.30/salt_sfc_restore.nc
-    - /g/data/vk83/experiments/inputs/access-om3/cice/grids/global.025deg/2024.03.28/grid.nc
-    - /g/data/vk83/experiments/inputs/access-om3/cice/grids/global.025deg/2024.03.28/kmt.nc
+    - /g/data/vk83/experiments/inputs/access-om3/cice/grids/global.025deg/2024.05.14/grid.nc
+    - /g/data/vk83/experiments/inputs/access-om3/cice/grids/global.025deg/2024.05.14/kmt.nc
     - /g/data/vk83/experiments/inputs/JRA-55/RYF/v1-4/data
  
 collate: false

--- a/ice_in
+++ b/ice_in
@@ -5,6 +5,7 @@
   dumpfreq = "y"
   dump_last = .true.
   histfreq = "d", "m", "x", "x", "x"
+  hist_time_axis = "middle"
   history_precision = 8
   ice_ic = 'default' 
   lcdf64 = .false.
@@ -128,24 +129,18 @@
   ! These fields are on by default (in ice_history_shared.F90) but lets turn them off
   !-----------------------------------
   f_tlon         = .false. , f_tlat         = .false.
-  f_ulon         = .false. ,  f_ulat         = .false.
-  f_nlon         = .false. ,  f_nlat         = .false.
-  f_elon         = .false. ,  f_elat         = .false.
-  f_umask        = .false.
-  f_nmask        = .false.
-  f_emask        = .false.
-  f_narea        = .false.
-  f_earea        = .false.
-  f_dxt          = .false.
-  f_dyt          = .false.
-  f_dxu          = .false.
-  f_dyu          = .false.
-  f_dxe          = .false.
-  f_dye          = .false.
-  f_dxn          = .false.
-  f_dyn          = .false.
-  f_HTN          = .false.
-  f_HTE          = .false.
+  f_ulon         = .false. , f_ulat         = .false.
+  f_nlon         = .false. , f_nlat         = .false.
+  f_elon         = .false. , f_elat         = .false.
+  f_tmask        = .false. , f_umask        = .false.
+  f_nmask        = .false. , f_emask        = .false.
+  f_tarea        = .false. , f_uarea        = .false.
+  f_narea        = .false. , f_earea        = .false.
+  f_dxt          = .false. , f_dyt          = .false.
+  f_dxu          = .false. , f_dyu          = .false.
+  f_dxe          = .false. , f_dye          = .false.
+  f_dxn          = .false. , f_dyn          = .false.
+  f_HTN          = .false. , f_HTE          = .false.
   f_albpnd = 'x'
   f_atmdir = 'x' , f_atmspd = 'x'
   f_coszen = 'x'

--- a/ice_in
+++ b/ice_in
@@ -7,6 +7,7 @@
   histfreq = "d", "m", "x", "x", "x"
   hist_time_axis = "middle"
   history_deflate = 1
+  history_chunksize = 720, 540
   history_precision = 8
   restart_deflate = 1
   ice_ic = 'default' 

--- a/ice_in
+++ b/ice_in
@@ -127,6 +127,10 @@
   !-----------------------------------
   ! These fields are on by default (in ice_history_shared.F90) but lets turn them off
   !-----------------------------------
+  f_tlon         = .false. , f_tlat         = .false.
+  f_ulon         = .false. ,  f_ulat         = .false.
+  f_nlon         = .false. ,  f_nlat         = .false.
+  f_elon         = .false. ,  f_elat         = .false.
   f_albpnd = 'x'
   f_atmdir = 'x' , f_atmspd = 'x'
   f_coszen = 'x'

--- a/ice_in
+++ b/ice_in
@@ -6,7 +6,9 @@
   dump_last = .true.
   histfreq = "d", "m", "x", "x", "x"
   hist_time_axis = "middle"
+  history_deflate = 1
   history_precision = 8
+  restart_deflate = 1
   ice_ic = 'default' 
   lcdf64 = .false.
   npt = 35040

--- a/ice_in
+++ b/ice_in
@@ -1,8 +1,6 @@
 &setup_nml
   bfbflag = "off" 
   conserv_check = .false.
-  debug_forcing = .true.
-  debug_model = .true.
   diagfreq = 960
   dumpfreq = "y"
   dump_last = .true.

--- a/ice_in
+++ b/ice_in
@@ -125,6 +125,7 @@
   f_fsurfn_ai = "m"
   f_hi = "md"
   f_hs = "md"
+  f_sifb = "md"
   f_snoice = "md"
   f_uvel = "md" , f_vvel = "md"
   f_vicen = "m"

--- a/ice_in
+++ b/ice_in
@@ -131,6 +131,21 @@
   f_ulon         = .false. ,  f_ulat         = .false.
   f_nlon         = .false. ,  f_nlat         = .false.
   f_elon         = .false. ,  f_elat         = .false.
+  f_umask        = .false.
+  f_nmask        = .false.
+  f_emask        = .false.
+  f_narea        = .false.
+  f_earea        = .false.
+  f_dxt          = .false.
+  f_dyt          = .false.
+  f_dxu          = .false.
+  f_dyu          = .false.
+  f_dxe          = .false.
+  f_dye          = .false.
+  f_dxn          = .false.
+  f_dyn          = .false.
+  f_HTN          = .false.
+  f_HTE          = .false.
   f_albpnd = 'x'
   f_atmdir = 'x' , f_atmspd = 'x'
   f_coszen = 'x'

--- a/manifests/input.yaml
+++ b/manifests/input.yaml
@@ -77,15 +77,15 @@ work/input/access-om2-025deg-nomask-ESMFmesh.nc:
     binhash: 29f147c299de419f5a32d129491a8ea2
     md5: db5407804d759435c6846d2d2c661a6e
 work/input/grid.nc:
-  fullpath: /g/data/vk83/experiments/inputs/access-om3/cice/grids/global.025deg/2024.03.28/grid.nc
+  fullpath: /g/data/vk83/experiments/inputs/access-om3/cice/grids/global.025deg/2024.05.14/grid.nc
   hashes:
-    binhash: 7cace0a81c147d2a5d64efd879ff8b43
-    md5: 6946bd45cb5cbf932f869b39eb68bee2
+    binhash: 352d9abb56c3c8fefcd3748bb69fafdc
+    md5: c859e1e759f33ab39527c7b30a7dbd88
 work/input/kmt.nc:
-  fullpath: /g/data/vk83/experiments/inputs/access-om3/cice/grids/global.025deg/2024.03.28/kmt.nc
+  fullpath: /g/data/vk83/experiments/inputs/access-om3/cice/grids/global.025deg/2024.05.14/kmt.nc
   hashes:
-    binhash: 42459f59c39836197df11a44ce49c8db
-    md5: d87ca7229f1a579af6f3b308af16e3d1
+    binhash: 2e46b34c831a515bd2589fd1c2d21276
+    md5: 3b9b6269b24a33de75cef4e36fc35376
 work/input/ocean_hgrid.nc:
   fullpath: /g/data/vk83/experiments/inputs/access-om3/mom/grids/mosaic/global.025deg/2020.05.30/ocean_hgrid.nc
   hashes:

--- a/nuopc.runconfig
+++ b/nuopc.runconfig
@@ -311,6 +311,7 @@ ATM_attributes::
 ::
 
 ICE_attributes::
+     eps_imesh = 1e-13 # allowed error between angles in mesh file and cice grid
      Verbosity = off
 ::
 


### PR DESCRIPTION
Changes described in https://github.com/COSIMA/access-om3/issues/113 for move to CICE 6.5. Uncompressed daily history output is 15MB, compressed is 2MB.

Add new cice grid from https://github.com/COSIMA/esmgrids/pull/6 and (https://github.com/COSIMA/access-om2/issues/279 )

Tigthen grid angle check limits (per https://github.com/COSIMA/access-om3/issues/144)

Add freeboard as a default history output to make validation easier.

Turn off metadata for development work.

Changes should be described in each commit, I will not squash the commits.