### PR TITLE
Unset `MAX_DELTA_SRESTORE`: `025deg_jra55do_ryf`

### DIFF
--- a/MOM_input
+++ b/MOM_input
@@ -624,8 +624,6 @@ SALT_RESTORE_FILE = "salt_sfc_restore.nc" ! default = "salt_restore.nc"
 SRESTORE_AS_SFLUX = True        !   [Boolean] default = False
                                 ! If true, the restoring of salinity is applied as a salt flux instead of as a
                                 ! freshwater flux.
-MAX_DELTA_SRESTORE = 0.5        !   [PSU or g kg-1] default = 999.0
-                                ! The maximum salinity difference used in restoring terms.
 GUST_CONST = 0.02               !   [Pa] default = 0.0
                                 ! The background gustiness in the winds.
 


### PR DESCRIPTION
Unsets `MAX_DELTA_SRESTORE` in MOM_input so that it takes the default `MAX_DELTA_SRESTORE = 999.0`. See https://github.com/COSIMA/access-om3/issues/167