### PR TITLE
[0.25deg] Disable TIDES and associated parameters

### DIFF
--- a/MOM_input
+++ b/MOM_input
@@ -346,8 +346,6 @@ USE_KH_IN_MEKE = True           !   [Boolean] default = False
 ! === module MOM_porous_barriers ===
 
 ! === module MOM_dynamics_split_RK2 ===
-TIDES = True                    !   [Boolean] default = False
-                                ! If true, apply tidal momentum forcing.
 
 ! === module MOM_continuity ===
 
@@ -370,13 +368,6 @@ BOUND_CORIOLIS = True           !   [Boolean] default = False
                                 ! possible to use centered difference thickness fluxes.
 
 ! === module MOM_tidal_forcing ===
-TIDE_M2 = True                  !   [Boolean] default = False
-                                ! If true, apply tidal momentum forcing at the M2 frequency. This is only used
-                                ! if TIDES is true.
-TIDE_SAL_SCALAR_VALUE = 0.094   !   [m m-1]
-                                ! The constant of proportionality between sea surface height (really it should
-                                ! be bottom pressure) anomalies and bottom geopotential anomalies. This is only
-                                ! used if TIDES and TIDE_USE_SAL_SCALAR are true.
 
 ! === module MOM_PressureForce ===
 

--- a/docs/MOM_parameter_doc.all
+++ b/docs/MOM_parameter_doc.all
@@ -1112,7 +1112,7 @@ PORBAR_ETA_INTERP = "MAX"       ! default = "MAX"
                                 !    HARMONIC - harmonic mean of the adjacent cells
 
 ! === module MOM_dynamics_split_RK2 ===
-TIDES = True                    !   [Boolean] default = False
+TIDES = False                   !   [Boolean] default = False
                                 ! If true, apply tidal momentum forcing.
 BE = 0.6                        !   [nondim] default = 0.6
                                 ! If SPLIT is true, BE determines the relative weighting of a  2nd-order
@@ -1219,7 +1219,7 @@ PV_ADV_SCHEME = "PV_ADV_CENTERED" ! default = "PV_ADV_CENTERED"
                                 !    PV_ADV_UPWIND1  - upwind, first order
 
 ! === module MOM_tidal_forcing ===
-TIDE_M2 = True                  !   [Boolean] default = False
+TIDE_M2 = False                 !   [Boolean] default = False
                                 ! If true, apply tidal momentum forcing at the M2 frequency. This is only used
                                 ! if TIDES is true.
 TIDE_S2 = False                 !   [Boolean] default = False
@@ -1255,7 +1255,7 @@ TIDAL_SAL_FROM_FILE = False     !   [Boolean] default = False
 USE_PREVIOUS_TIDES = False      !   [Boolean] default = False
                                 ! If true, use the SAL from the previous iteration of the tides to facilitate
                                 ! convergent iteration. This is only used if TIDES is true.
-TIDE_USE_SAL_SCALAR = True      !   [Boolean] default = True
+TIDE_USE_SAL_SCALAR = False     !   [Boolean] default = True
                                 ! If true and TIDES is true, use the scalar approximation when calculating
                                 ! self-attraction and loading.
 TIDE_SAL_SCALAR_VALUE = 0.094   !   [m m-1]

--- a/docs/MOM_parameter_doc.all
+++ b/docs/MOM_parameter_doc.all
@@ -1255,7 +1255,7 @@ TIDAL_SAL_FROM_FILE = False     !   [Boolean] default = False
 USE_PREVIOUS_TIDES = False      !   [Boolean] default = False
                                 ! If true, use the SAL from the previous iteration of the tides to facilitate
                                 ! convergent iteration. This is only used if TIDES is true.
-TIDE_USE_SAL_SCALAR = False     !   [Boolean] default = True
+TIDE_USE_SAL_SCALAR = True     !   [Boolean] default = True
                                 ! If true and TIDES is true, use the scalar approximation when calculating
                                 ! self-attraction and loading.
 TIDE_SAL_SCALAR_VALUE = 0.094   !   [m m-1]


### PR DESCRIPTION
Disable `TIDES` and associated parameters. One thing to note: we might need to add the `INT_TIDE_DISSIPATION` parameter to parameterise the turbulent mixing generated by breaking internal waves for local dissipation. To do this, `tideamp.nc`, which contains the averaged tidal flow amplitudes must be included in the input files.

See https://github.com/COSIMA/access-om3/issues/176