### PR TITLE
Update to latest ACCESS-OM3 executable: `1deg_jra55do_iaf`

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -17,7 +17,7 @@ walltime: 01:00:00
 jobname: 1deg_jra55do_iaf
 
 model: access-om3
-exe: /g/data/ik11/spack/0.21.2/opt/linux-rocky8-cascadelake/intel-2021.10.0/access-om3-d6813d6b9e1df560ac3f6ba6a605daab9cfd9569_main-5pjh7z2/bin/access-om3-MOM6-CICE6
+exe: /g/data/ik11/spack/0.21.2/opt/linux-rocky8-cascadelake/intel-2021.10.0/access-om3-69f719964a27e23deae3923d60af01a081cc3fc0_main-fkzzqnp/bin/access-om3-MOM6-CICE6
 input: 
     - /g/data/vk83/experiments/inputs/access-om3/share/meshes/global.1deg/2024.01.25/access-om2-1deg-ESMFmesh.nc
     - /g/data/vk83/experiments/inputs/access-om3/share/meshes/global.1deg/2024.01.25/access-om2-1deg-nomask-ESMFmesh.nc

--- a/manifests/exe.yaml
+++ b/manifests/exe.yaml
@@ -2,7 +2,7 @@ format: yamanifest
 version: 1.0
 ---
 work/access-om3-MOM6-CICE6:
-  fullpath: /g/data/ik11/spack/0.21.2/opt/linux-rocky8-cascadelake/intel-2021.10.0/access-om3-d6813d6b9e1df560ac3f6ba6a605daab9cfd9569_main-5pjh7z2/bin/access-om3-MOM6-CICE6
+  fullpath: /g/data/ik11/spack/0.21.2/opt/linux-rocky8-cascadelake/intel-2021.10.0/access-om3-69f719964a27e23deae3923d60af01a081cc3fc0_main-fkzzqnp/bin/access-om3-MOM6-CICE6
   hashes:
-    binhash: 4b05dc495b4fe5ce2e71fa9a7ff62f72
-    md5: ba3b677b7c386c09e6430617c26cab58
+    binhash: 2b81c015c844fe20b7f03eb463c2badf
+    md5: bf9a7bdcc4c1e6fa94dc248431b9aa3d


### PR DESCRIPTION
This PR updates the ACCESS-OM3 executable to include recent code changes. See https://github.com/COSIMA/access-om3/issues/183