### PR TITLE
Turn on AUTO_MASKTABLE 

### DIFF
--- a/MOM_input
+++ b/MOM_input
@@ -616,3 +616,5 @@ GUST_CONST = 0.02               !   [Pa] default = 0.0
 ! === module MOM_file_parser ===
 FATAL_UNUSED_PARAMS = True      !   [Boolean] default = False
                                 ! If true, kill the run if there are any unused parameters.
+AUTO_MASKTABLE = True           !   [Boolean] default = False
+                                ! Turn on automatic mask table generation to eliminate land blocks.

--- a/docs/MOM_parameter_doc.layout
+++ b/docs/MOM_parameter_doc.layout
@@ -23,9 +23,9 @@ THIN_HALO_UPDATES = True        !   [Boolean] default = True
                                 ! statically determined at compile time.  Otherwise the sizes are not determined
                                 ! until run time. The STATIC option is substantially faster, but does not allow
                                 ! the PE count to be changed at run time.  This can only be set at compile time.
-AUTO_MASKTABLE = False          !   [Boolean] default = False
+AUTO_MASKTABLE = True           !   [Boolean] default = False
                                 ! Turn on automatic mask table generation to eliminate land blocks.
-MASKTABLE = "MOM_mask_table"    ! default = "MOM_mask_table"
+MASKTABLE = "MOM_auto_mask_table"    ! default = "MOM_mask_table"
                                 ! A text file to specify n_mask, layout and mask_list. This feature masks out
                                 ! processors that contain only land points. The first line of mask_table is the
                                 ! number of regions to be masked out. The second line is the layout of the model
@@ -46,6 +46,10 @@ NJPROC = 30                     !
                                 ! in MOM_memory.h at compile time.
 LAYOUT = 36, 30                 !
                                 ! The processor layout that was actually used.
+AUTO_IO_LAYOUT_FAC = 0          ! default = 0
+                                ! When AUTO_MASKTABLE is enabled, io layout is calculated by performing integer
+                                ! division of the runtime-determined domain layout with this factor. If the
+                                ! factor is set to 0 (default), the io layout is set to 1,1.
 IO_LAYOUT = 1, 1                ! default = 1
                                 ! The processor layout to be used, or 0,0 to automatically set the io_layout to
                                 ! be the same as the layout.


### PR DESCRIPTION
to automatically generate a mask table to exclude land masks.

See https://github.com/COSIMA/access-om3/issues/184