### PR TITLE
Fix bug in nuopc.runconfig by removing the equal sign ('=') from comments (after '#')

### DIFF
--- a/nuopc.runconfig
+++ b/nuopc.runconfig
@@ -286,7 +286,7 @@ CLOCK_attributes::
      history_ymd = -999
      ice_cpl_dt = 99999 #not used
      lnd_cpl_dt = 99999 #not used
-     ocn_cpl_dt =  1800 #ignored (coupling timestep set by nuopc.runseq) unless stop_option=nsteps
+     ocn_cpl_dt =  1800 #ignored (coupling timestep set by nuopc.runseq) unless stop_option is nsteps
      restart_n = 1
      restart_option = nmonths
      restart_ymd = -999


### PR DESCRIPTION
Fix bug caused by the equal sign '=' from comments (after '#')

```
...
  72 [gadi-cpu-clx-0238:1008973:0:1008973] Caught signal 11 (Segmentation fault: address not mapped to object at address 0x65d8)
  73 [gadi-cpu-clx-0238:1008975:0:1008975] Caught signal 11 (Segmentation fault: address not mapped to object at address 0x65d8)
  74 ==== backtrace (tid:1008976) ====
  75  0 0x0000000000012d20 __funlockfile()  :0
  76  1 0x0000000002e01faf mom_mp_mom_state_is_synchronized_()  /jobfs/121983958.gadi-pbs/ds0092/spack-stage/spack-stage-access-om3-63ed4a4777aeac0c6     2720ddbe7f85e4ed16f82eb_main-xekfuu46z2ztbywtak2u3oenjedrynn4/spack-src/MOM6/MOM6/src/core/MOM.F90:3861
  77  2 0x0000000002d749df mom_ocean_model_nuopc_mp_ocean_model_restart_()  /jobfs/121983958.gadi-pbs/ds0092/spack-stage/spack-stage-access-om3-63ed4     a4777aeac0c62720ddbe7f85e4ed16f82eb_main-xekfuu46z2ztbywtak2u3oenjedrynn4/spack-build-xekfuu4/MOM6/mom_ocean_model_nuopc.F90:721
  78  3 0x0000000002d35716 mom_cap_mod_mp_modeladvance_()  /jobfs/121983958.gadi-pbs/ds0092/spack-stage/spack-stage-access-om3-63ed4a4777aeac0c62720d     dbe7f85e4ed16f82eb_main-xekfuu46z2ztbywtak2u3oenjedrynn4/spack-build-xekfuu4/MOM6/mom_cap.F90:1955
  79  4 0x00000000020a637f ESMCI::MethodElement::execute()  /jobfs/115061931.gadi-pbs/mo1833/spack-stage/spack-stage-esmf-8.5.0-ox5q2shmsrzlmmckqxwqg     vaih7zxxthj/spack-src/src/Superstructure/Component/src/ESMCI_MethodTable.C:377
...
2783 45 0x000000000043150d main()  ???:0
2784 46 0x000000000003a7e5 __libc_start_main()  ???:0
2785 47 0x000000000043142e _start()  ???:0
2786 =================================
2787 --------------------------------------------------------------------------
2788 mpirun noticed that process rank 9 with PID 0 on node gadi-cpu-clx-0238 exited on signal 11 (Segmentation fault).
2789 --------------------------------------------------------------------------
```

This fix resolves the above error.