### PR TITLE
Fix bug in nuopc.runconfig by removing the equal sign ('=') from comments (after '#') (#98)

### DIFF
--- a/nuopc.runconfig
+++ b/nuopc.runconfig
@@ -286,7 +286,7 @@ CLOCK_attributes::
      history_ymd = -999
      ice_cpl_dt = 99999 #not used
      lnd_cpl_dt = 99999 #not used
-     ocn_cpl_dt = 1800 #ignored (coupling timestep set by nuopc.runseq) unless stop_option=nsteps
+     ocn_cpl_dt = 1800 #ignored (coupling timestep set by nuopc.runseq) unless stop_option is nsteps
      restart_n = 1
      restart_option = nmonths
      restart_ymd = -999


### PR DESCRIPTION
Cherry-pick from https://github.com/COSIMA/MOM6-CICE6/pull/98