### PR TITLE
`1deg_jra55do_iaf`: Fix incorrect `ocn_cpl_dt` in `nuopc.runconfig`

### DIFF
--- a/nuopc.runconfig
+++ b/nuopc.runconfig
@@ -286,7 +286,7 @@ CLOCK_attributes::
      history_ymd = -999
      ice_cpl_dt = 99999 #not used
      lnd_cpl_dt = 99999 #not used
-     ocn_cpl_dt = 1800 #ignored (coupling timestep set by nuopc.runseq) unless stop_option is nsteps
+     ocn_cpl_dt = 3600 #ignored (coupling timestep set by nuopc.runseq) unless stop_option is nsteps
      restart_n = 1
      restart_option = nmonths
      restart_ymd = -999


### PR DESCRIPTION
https://github.com/COSIMA/MOM6-CICE6/pull/97 changed the value of `ocn_cpl_dt` in the `nuopc.runconfig` to be inconsistent with the `nuopc.runseq`. This PR fixes it.