### PR TITLE
Output 3D MOM diagnostics on vertically remapped rho2 and z coords

### DIFF
--- a/MOM_input
+++ b/MOM_input
@@ -21,7 +21,7 @@ AUTO_MASKTABLE = True           !   [Boolean] default = False
                                 ! Turn on automatic mask table generation to eliminate land blocks.
 AUTO_IO_LAYOUT_FAC = 6          ! default = 0
                                 ! When AUTO_MASKTABLE is enabled, io layout is calculated by performing integer
-                                ! division of the runtime-determined domain layout with this factor. If the 
+                                ! division of the runtime-determined domain layout with this factor. If the
                                 ! factor is set to 0 (default), the io layout is set to 1,1.
 
 ! This section is formatted the same as the MOM_parameter_short.doc output file.
@@ -244,13 +244,41 @@ Z_INIT_REMAPPING_USE_OM4_SUBCELLS = False !   [Boolean] default = True
                                 ! to false.
 
 ! === module MOM_diag_mediator ===
+NUM_DIAG_COORDS = 2             ! default = 1
+                                ! The number of diagnostic vertical coordinates to use. For each coordinate, an
+                                ! entry in DIAG_COORDS must be provided.
 DIAG_REMAPPING_USE_OM4_SUBCELLS = False !   [Boolean] default = True
                                 ! If true, use the OM4 remapping-via-subcells algorithm for diagnostics. See
                                 ! REMAPPING_USE_OM4_SUBCELLS for details. We recommend setting this option to
                                 ! false.
+DIAG_COORDS = "z Z ZSTAR", "rho2 RHO2 RHO" !
+                                ! A list of string tuples associating diag_table modules to a coordinate
+                                ! definition used for diagnostics. Each string is of the form
+                                ! "MODULE_SUFFIX,PARAMETER_SUFFIX,COORDINATE_NAME".
 DIAG_COORD_DEF_Z = "FILE:ocean_vgrid.nc,interfaces=zeta" ! default = "WOA09"
                                 ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter DIAG_COORD_RES_Z
+                                !  UNIFORM[:N] - uniformly distributed
+                                !  FILE:string - read from a file. The string specifies
+                                !                the filename and variable name, separated
+                                !                by a comma or space, e.g. FILE:lev.nc,dz
+                                !                or FILE:lev.nc,interfaces=zw
+                                !  WOA09[:N]   - the WOA09 vertical grid (approximately)
+                                !  WOA09INT[:N] - layers spanned by the WOA09 depths
+                                !  WOA23INT[:N] - layers spanned by the WOA23 depths
+                                !  FNC1:string - FNC1:dz_min,H_total,power,precision
+                                !  HYBRID:string - read from a file. The string specifies
+                                !                the filename and two variable names, separated
+                                !                by a comma or space, for sigma-2 and dz. e.g.
+                                !                HYBRID:vgrid.nc,sigma2,dz
+REGRIDDING_ANSWER_DATE = 99991231 ! default = 20181231
+                                ! The vintage of the expressions and order of arithmetic to use for regridding.
+                                ! Values below 20190101 result in the use of older, less accurate expressions
+                                ! that were in use at the end of 2018.  Higher values result in the use of more
+                                ! robust and accurate forms of mathematically equivalent expressions.
+DIAG_COORD_DEF_RHO2 = "RFNC1:76,999.5,1020.,1034.1,3.1,1041.,0.002" ! default = "WOA09"
+                                ! Determines how to specify the coordinate resolution. Valid options are:
+                                !  PARAM       - use the vector-parameter DIAG_COORD_RES_RHO2
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
                                 !                the filename and variable name, separated
@@ -277,10 +305,10 @@ MEKE_BGSRC = 1.0E-13            !   [W kg-1] default = 0.0
                                 ! A background energy source for MEKE.
 MEKE_KHMEKE_FAC = 1.0           !   [nondim] default = 0.0
                                 ! A factor that maps MEKE%Kh to Kh for MEKE itself.
-MEKE_ALPHA_RHINES = 0.15        !   [nondim] default = 0.05
+MEKE_ALPHA_RHINES = 0.15        !   [nondim] default = 0.0
                                 ! If positive, is a coefficient weighting the Rhines scale in the expression for
                                 ! mixing length used in MEKE-derived diffusivity.
-MEKE_ALPHA_EADY = 0.15          !   [nondim] default = 0.05
+MEKE_ALPHA_EADY = 0.15          !   [nondim] default = 0.0
                                 ! If positive, is a coefficient weighting the Eady length scale in the
                                 ! expression for mixing length used in MEKE-derived diffusivity.
 
@@ -303,15 +331,6 @@ USE_STORED_SLOPES = True        !   [Boolean] default = False
                                 ! If true, the isopycnal slopes are calculated once and stored for re-use. This
                                 ! uses more memory but avoids calling the equation of state more times than
                                 ! should be necessary.
-INTERPOLATE_RES_FN = False      !   [Boolean] default = True
-                                ! If true, interpolate the resolution function to the velocity points from the
-                                ! thickness points; otherwise interpolate the wave speed and calculate the
-                                ! resolution function independently at each point.
-GILL_EQUATORIAL_LD = True       !   [Boolean] default = False
-                                ! If true, uses Gill's definition of the baroclinic equatorial deformation
-                                ! radius, otherwise, if false, use Pedlosky's definition. These definitions
-                                ! differ by a factor of 2 in front of the beta term in the denominator. Gill's
-                                ! is the more appropriate definition.
 EBT_REMAPPING_USE_OM4_SUBCELLS = False !   [Boolean] default = True
                                 ! If true, use the OM4 remapping-via-subcells algorithm for calculating EBT
                                 ! structure. See REMAPPING_USE_OM4_SUBCELLS for details. We recommend setting
@@ -338,6 +357,7 @@ BBL_THICK_MIN = 0.1             !   [m] default = 0.0
 KV = 0.0                        !   [m2 s-1]
                                 ! The background kinematic viscosity in the interior. The molecular value, ~1e-6
                                 ! m2 s-1, may be used.
+
 ! === module MOM_thickness_diffuse ===
 KHTH_MAX_CFL = 0.1              !   [nondimensional] default = 0.8
                                 ! The maximum value of the local diffusive CFL ratio that is permitted for the
@@ -385,8 +405,6 @@ AH_VEL_SCALE = 0.01             !   [m s-1] default = 0.0
                                 ! scaled viscosity, the Smagorinsky and Leith viscosities, and AH.
 SMAGORINSKY_AH = True           !   [Boolean] default = False
                                 ! If true, use a biharmonic Smagorinsky nonlinear eddy viscosity.
-SMAG_BI_CONST = 0.06            !   [nondim] default = 0.0
-                                ! The nondimensional biharmonic Smagorinsky constant, typically 0.015 - 0.06.
 BACKSCATTER_UNDERBOUND = False  !   [Boolean] default = True
                                 ! If true, the bounds on the biharmonic viscosity are allowed to increase where
                                 ! the Laplacian viscosity is negative (due to backscatter parameterizations)
@@ -394,6 +412,8 @@ BACKSCATTER_UNDERBOUND = False  !   [Boolean] default = True
                                 ! when no Laplacian viscosity is applied.  The default is true for historical
                                 ! reasons, but this option probably should not be used because it can contribute
                                 ! to numerical instabilities.
+SMAG_BI_CONST = 0.06            !   [nondim] default = 0.0
+                                ! The nondimensional biharmonic Smagorinsky constant, typically 0.015 - 0.06.
 FRICTWORK_BUG = False           !   [Boolean] default = True
                                 ! If true, retain an answer-changing bug in calculating the FrictWork, which
                                 ! cancels the h in thickness flux and the h at velocity point. This isnot
@@ -439,25 +459,27 @@ MIXEDLAYER_RESTRAT = True       !   [Boolean] default = False
                                 ! If true, a density-gradient dependent re-stratifying flow is imposed in the
                                 ! mixed layer. Can be used in ALE mode without restriction but in layer mode can
                                 ! only be used if BULKMIXEDLAYER is true.
-MLE%USE_BODNER23 = True         !   [Boolean] default = False
+MLE%
+USE_BODNER23 = True             !   [Boolean] default = False
                                 ! If true, use the Bodner et al., 2023, formulation of the re-stratifying
                                 ! mixed-layer restratification parameterization. This only works in ALE mode.
-MLE%CR = 0.0175                 !   [nondim] default = 0.0
+CR = 0.0175                     !   [nondim] default = 0.0
                                 ! The efficiency coefficient in eq 27 of Bodner et al., 2023.
-MLE%BLD_DECAYING_TFILTER = 8.64E+04 !   [s] default = 0.0
+BLD_DECAYING_TFILTER = 8.64E+04 !   [s] default = 0.0
                                 ! The time-scale for a running-mean filter applied to the boundary layer depth
                                 ! (BLD) when the BLD is shallower than the running mean. A value of 0
                                 ! instantaneously sets the running mean to the current value of BLD.
-MLE%MLD_DECAYING_TFILTER = 2.592E+06 !   [s] default = 0.0
+MLD_DECAYING_TFILTER = 2.592E+06 !   [s] default = 0.0
                                 ! The time-scale for a running-mean filter applied to the time-filtered BLD,
                                 ! when the latter is shallower than the running mean. A value of 0
                                 ! instantaneously sets the running mean to the current value filtered BLD.
-MLE%MIN_WSTAR2 = 1.0E-09        !   [m2 s-2] default = 1.0E-24
+MIN_WSTAR2 = 1.0E-09            !   [m2 s-2] default = 1.0E-24
                                 ! The minimum lower bound to apply to the vertical momentum flux, w'u', in the
                                 ! Bodner et al., restratification parameterization. This avoids a
                                 ! division-by-zero in the limit when u* and the buoyancy flux are zero.  The
                                 ! default is less than the molecular viscosity of water times the Coriolis
                                 ! parameter a micron away from the equator.
+%MLE
 MLE_USE_PBL_MLD = True          !   [Boolean] default = False
                                 ! If true, the MLE parameterization will use the mixed-layer depth provided by
                                 ! the active PBL parameterization. If false, MLE will estimate a MLD based on a
@@ -481,28 +503,7 @@ EPBL_IS_ADDITIVE = False        !   [Boolean] default = True
                                 ! If true, the diffusivity from ePBL is added to all other diffusivities.
                                 ! Otherwise, the larger of kappa-shear and ePBL diffusivities are used.
 
-! === module MOM_CVMix_KPP ===
-! This is the MOM wrapper to CVMix:KPP
-! See http://cvmix.github.io/
-
-! === module MOM_CVMix_conv ===
-! Parameterization of enhanced mixing due to convection via CVMix
-
 ! === module MOM_set_diffusivity ===
-BBL_EFFIC = 0.01                !   [nondim] default = 0.2
-                                ! The efficiency with which the energy extracted by bottom drag drives BBL
-                                ! diffusion.  This is only used if BOTTOMDRAGLAW is true.
-BBL_MIXING_AS_MAX = False       !   [Boolean] default = True
-                                ! If true, take the maximum of the diffusivity from the BBL mixing and the other
-                                ! diffusivities. Otherwise, diffusivity from the BBL_mixing is simply added.
-USE_LOTW_BBL_DIFFUSIVITY = True !   [Boolean] default = False
-                                ! If true, uses a simple, imprecise but non-coordinate dependent, model of BBL
-                                ! mixing diffusivity based on Law of the Wall. Otherwise, uses the original BBL
-                                ! scheme.
-SIMPLE_TKE_TO_KD = True         !   [Boolean] default = False
-                                ! If true, uses a simple estimate of Kd/TKE that will work for arbitrary
-                                ! vertical coordinates. If false, calculates Kd/TKE and bounds based on exact
-                                ! energetics for an isopycnal layer-formulation.
 
 ! === module MOM_tidal_mixing ===
 ! Vertical Tidal Mixing Parameterization
@@ -533,10 +534,24 @@ READ_TIDEAMP = True             !   [Boolean] default = False
 H2_FILE = "bottom_roughness.nc" !
                                 ! The path to the file containing the sub-grid-scale topographic roughness
                                 ! amplitude with INT_TIDE_DISSIPATION.
+BBL_EFFIC = 0.01                !   [nondim] default = 0.2
+                                ! The efficiency with which the energy extracted by bottom drag drives BBL
+                                ! diffusion.  This is only used if BOTTOMDRAGLAW is true.
+BBL_MIXING_AS_MAX = False       !   [Boolean] default = True
+                                ! If true, take the maximum of the diffusivity from the BBL mixing and the other
+                                ! diffusivities. Otherwise, diffusivity from the BBL_mixing is simply added.
+USE_LOTW_BBL_DIFFUSIVITY = True !   [Boolean] default = False
+                                ! If true, uses a simple, imprecise but non-coordinate dependent, model of BBL
+                                ! mixing diffusivity based on Law of the Wall. Otherwise, uses the original BBL
+                                ! scheme.
+SIMPLE_TKE_TO_KD = True         !   [Boolean] default = False
+                                ! If true, uses a simple estimate of Kd/TKE that will work for arbitrary
+                                ! vertical coordinates. If false, calculates Kd/TKE and bounds based on exact
+                                ! energetics for an isopycnal layer-formulation.
 
 ! === module MOM_bkgnd_mixing ===
 ! Adding static vertical background mixing coefficients
-KD = 1.5E-05                    !   [m2 s-1]
+KD = 1.5E-05                    !   [m2 s-1] default = 0.0
                                 ! The background diapycnal diffusivity of density in the interior. Zero or the
                                 ! molecular value, ~1e-7 m2 s-1, may be used.
 KD_MIN = 2.0E-06                !   [m2 s-1] default = 1.5E-07
@@ -563,7 +578,7 @@ USE_JACKSON_PARAM = True        !   [Boolean] default = False
                                 ! parameterization.
 VERTEX_SHEAR = True             !   [Boolean] default = False
                                 ! If true, do the calculations of the shear-driven mixing at the cell vertices
-                                ! (i.e., the vorticity points)
+                                ! (i.e., the vorticity points).
 MAX_RINO_IT = 25                !   [nondim] default = 50
                                 ! The maximum number of iterations that may be used to estimate the Richardson
                                 ! number driven mixing.
@@ -571,12 +586,6 @@ USE_RESTRICTIVE_TOLERANCE_CHECK = True !   [Boolean] default = False
                                 ! If true, uses the more restrictive tolerance check to determine if a timestep
                                 ! is acceptable for the KS_it outer iteration loop.  False uses the original
                                 ! less restrictive check.
-
-! === module MOM_CVMix_shear ===
-! Parameterization of shear-driven turbulence via CVMix (various options)
-
-! === module MOM_CVMix_ddiff ===
-! Parameterization of mixing due to double diffusion processes via CVMix
 
 ! === module MOM_diabatic_aux ===
 ! The following parameters are used for auxiliary diabatic processes.
@@ -596,7 +605,7 @@ TKE_DECAY = 0.01                !   [nondim] default = 2.5
 EPBL_MSTAR_SCHEME = "OM4"       ! default = "CONSTANT"
                                 ! EPBL_MSTAR_SCHEME selects the method for setting mstar.  Valid values are:
                                 !    CONSTANT   - Use a fixed mstar given by MSTAR
-                                !    OM4        - Use L_Ekman/L_Obukhov in the sabilizing limit, as in OM4
+                                !    OM4        - Use L_Ekman/L_Obukhov in the stabilizing limit, as in OM4
                                 !    REICHL_H18 - Use the scheme documented in Reichl & Hallberg, 2018.
 MSTAR_CAP = 1.25                !   [nondim] default = -1.0
                                 ! If this value is positive, it sets the maximum value of mstar allowed in ePBL.
@@ -614,9 +623,6 @@ NSTAR = 0.06                    !   [nondim] default = 0.2
 MSTAR_CONV_ADJ = 0.667          !   [nondim] default = 0.0
                                 ! Coefficient used for reducing mstar during convection due to reduction of
                                 ! stable density gradient.
-USE_MLD_ITERATION = True        !   [Boolean] default = False
-                                ! A logical that specifies whether or not to use the distance to the bottom of
-                                ! the actively turbulent boundary layer to help set the EPBL length scale.
 EPBL_TRANSITION_SCALE = 0.01    !   [nondim] default = 0.1
                                 ! A scale for the mixing length in the transition layer at the edge of the
                                 ! boundary layer as a fraction of the boundary layer thickness.
@@ -624,7 +630,7 @@ MIX_LEN_EXPONENT = 1.0          !   [nondim] default = 2.0
                                 ! The exponent applied to the ratio of the distance to the MLD and the MLD depth
                                 ! which determines the shape of the mixing length. This is only used if
                                 ! USE_MLD_ITERATION is True.
-USE_LA_LI2016 = True            !   [nondim] default = False
+USE_LA_LI2016 = True            !   [Boolean] default = False
                                 ! A logical to use the Li et al. 2016 (submitted) formula to determine the
                                 ! Langmuir number.
 EPBL_LANGMUIR_SCHEME = "ADDITIVE" ! default = "NONE"
@@ -669,12 +675,6 @@ CHECK_DIFFUSIVE_CFL = True      !   [Boolean] default = False
                                 ! equivalent of the CFL limit is not violated.  If false, always use the greater
                                 ! of 1 or MAX_TR_DIFFUSION_CFL iteration.
 
-! === module MOM_neutral_diffusion ===
-! This module implements neutral diffusion of tracers
-
-! === module MOM_hor_bnd_diffusion ===
-! This module implements horizontal diffusion of tracers near boundaries
-
 ! === module MOM_sum_output ===
 MAXTRUNC = 10000                !   [truncations save_interval-1] default = 0
                                 ! The run will be stopped, and the day set to a very large value if the velocity
@@ -696,23 +696,16 @@ RESTORE_SALINITY = True         !   [Boolean] default = False
                                 ! drives sea-surface salinity toward specified values.
 
 ! === module MOM_surface_forcing_nuopc ===
+LATENT_HEAT_FUSION = 3.337E+05  !   [J/kg] default = 3.34E+05
+                                ! The latent heat of fusion.
+LATENT_HEAT_VAPORIZATION = 2.501E+06 !   [J/kg] default = 2.5E+06
+                                ! The latent heat of fusion.
 MAX_P_SURF = 0.0                !   [Pa] default = -1.0
                                 ! The maximum surface pressure that can be exerted by the atmosphere and
                                 ! floating sea-ice or ice shelves. This is needed because the FMS coupling
                                 ! structure does not limit the water that can be frozen out of the ocean and the
                                 ! ice-ocean heat fluxes are treated explicitly.  No limit is applied if a
                                 ! negative value is used.
-USE_RIGID_SEA_ICE = True        !   [Boolean] default = False
-                                ! If true, sea-ice is rigid enough to exert a nonhydrostatic pressure that
-                                ! resist vertical motion.
-SEA_ICE_RIGID_MASS = 100.0      !   [kg m-2] default = 1000.0
-                                ! The mass of sea-ice per unit area at which the sea-ice starts to exhibit
-                                ! rigidity
-
-LATENT_HEAT_FUSION = 3.337E+05  !   [J/kg] default = 3.34E+05
-                                ! The latent heat of fusion.
-LATENT_HEAT_VAPORIZATION = 2.501E+06 !   [J/kg] default = 2.5E+06
-                                ! The latent heat of fusion.
 ADJUST_NET_FRESH_WATER_TO_ZERO = True !   [Boolean] default = False
                                 ! If true, adjusts the net fresh-water forcing seen by the ocean (including
                                 ! restoring) to zero.
@@ -730,3 +723,9 @@ SALT_RESTORE_FILE = "salt_sfc_restore.nc" ! default = "salt_restore.nc"
 SRESTORE_AS_SFLUX = True        !   [Boolean] default = False
                                 ! If true, the restoring of salinity is applied as a salt flux instead of as a
                                 ! freshwater flux.
+USE_RIGID_SEA_ICE = True        !   [Boolean] default = False
+                                ! If true, sea-ice is rigid enough to exert a nonhydrostatic pressure that
+                                ! resist vertical motion.
+SEA_ICE_RIGID_MASS = 100.0      !   [kg m-2] default = 1000.0
+                                ! The mass of sea-ice per unit area at which the sea-ice starts to exhibit
+                                ! rigidity

--- a/diagnostic_profiles/diag_table_standard
+++ b/diagnostic_profiles/diag_table_standard
@@ -41,46 +41,40 @@ ACCESS-OM3
 "ocean_model", "dxCvo", "dxCvo", "access-om3.mom6.static", "all", "none", "none", 1
 
 
-# monthly 3d fields
+# monthly 3d fields on z
 
-"access-om3.mom6.3d.h.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
-"ocean_model", "h", "h", "access-om3.mom6.3d.h.1mon.mean.%4yr", "all", "average", "none", 2
+"access-om3.mom6.3d.agessc.z.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model_z", "agessc", "agessc", "access-om3.mom6.3d.agessc.z.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.3d.agessc.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
-"ocean_model", "agessc", "agessc", "access-om3.mom6.3d.agessc.1mon.mean.%4yr", "all", "average", "none", 2
+"access-om3.mom6.3d.rhopot2.z.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model_z", "rhopot2", "rhopot2", "access-om3.mom6.3d.rhopot2.z.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.3d.rhopot2.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
-"ocean_model", "rhopot2", "rhopot2", "access-om3.mom6.3d.rhopot2.1mon.mean.%4yr", "all", "average", "none", 2
+"access-om3.mom6.3d.thetao.z.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model_z", "thetao", "thetao", "access-om3.mom6.3d.thetao.z.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.3d.thetao.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
-"ocean_model", "thetao", "thetao", "access-om3.mom6.3d.thetao.1mon.mean.%4yr", "all", "average", "none", 2
+"access-om3.mom6.3d.so.z.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model_z", "so", "so", "access-om3.mom6.3d.so.z.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.3d.so.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
-"ocean_model", "so", "so", "access-om3.mom6.3d.so.1mon.mean.%4yr", "all", "average", "none", 2
+"access-om3.mom6.3d.uo.z.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model_z", "uo", "uo", "access-om3.mom6.3d.uo.z.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.3d.uo.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
-"ocean_model", "uo", "uo", "access-om3.mom6.3d.uo.1mon.mean.%4yr", "all", "average", "none", 2
+"access-om3.mom6.3d.vo.z.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model_z", "vo", "vo", "access-om3.mom6.3d.vo.z.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.3d.vo.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
-"ocean_model", "vo", "vo", "access-om3.mom6.3d.vo.1mon.mean.%4yr", "all", "average", "none", 2
+"access-om3.mom6.3d.KE.z.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model_z", "KE", "KE", "access-om3.mom6.3d.KE.z.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.3d.uh.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
-"ocean_model", "uh", "uh", "access-om3.mom6.3d.uh.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.3d.vh.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
-"ocean_model", "vh", "vh", "access-om3.mom6.3d.vh.1mon.mean.%4yr", "all", "average", "none", 2
+# monthly 3d fields on rho2
 
-"access-om3.mom6.3d.uhGM.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
-"ocean_model", "uhGM", "uhGM", "access-om3.mom6.3d.uhGM.1mon.mean.%4yr", "all", "average", "none", 2
+"access-om3.mom6.3d.e.rho2.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model_rho2", "e", "e", "access-om3.mom6.3d.e.rho2.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.3d.vhGM.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
-"ocean_model", "vhGM", "vhGM", "access-om3.mom6.3d.vhGM.1mon.mean.%4yr", "all", "average", "none", 2
+"access-om3.mom6.3d.umo.rho2.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model_rho2", "umo", "umo", "access-om3.mom6.3d.umo.rho2.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.3d.thkcello.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
-"ocean_model", "thkcello", "thkcello", "access-om3.mom6.3d.thkcello.1mon.mean.%4yr", "all", "average", "none", 2
-
-"access-om3.mom6.3d.KE.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
-"ocean_model", "KE", "KE", "access-om3.mom6.3d.KE.1mon.mean.%4yr", "all", "average", "none", 2
+"access-om3.mom6.3d.vmo.rho2.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model_rho2", "vmo", "vmo", "access-om3.mom6.3d.vmo.rho2.1mon.mean.%4yr", "all", "average", "none", 2
 
 
 # monthly 2d fields

--- a/diagnostic_profiles/diag_table_standard
+++ b/diagnostic_profiles/diag_table_standard
@@ -103,17 +103,17 @@ ACCESS-OM3
 "access-om3.mom6.2d.salt_flux_added.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
 "ocean_model", "salt_flux_added", "salt_flux_added", "access-om3.mom6.2d.salt_flux_added.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.2d.Rd_dx.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
-"ocean_model", "Rd_dx", "Rd_dx", "access-om3.mom6.2d.Rd_dx.1mon.mean.%4yr", "all", "average", "none", 2
-
 "access-om3.mom6.2d.mlotst.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
 "ocean_model", "mlotst", "mlotst", "access-om3.mom6.2d.mlotst.1mon.mean.%4yr", "all", "average", "none", 2
 
 "access-om3.mom6.2d.speed.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
 "ocean_model", "speed", "speed", "access-om3.mom6.2d.speed.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.2d.SSH.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
-"ocean_model", "SSH", "SSH", "access-om3.mom6.2d.SSH.1mon.mean.%4yr", "all", "average", "none", 2
+"access-om3.mom6.2d.zos.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "zos", "zos", "access-om3.mom6.2d.zos.1mon.mean.%4yr", "all", "average", "none", 2
+
+"access-om3.mom6.2d.zossq.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model", "zossq", "zossq", "access-om3.mom6.2d.zossq.1mon.mean.%4yr", "all", "average", "none", 2
 
 "access-om3.mom6.2d.tauuo.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
 "ocean_model", "tauuo", "tauuo", "access-om3.mom6.2d.tauuo.1mon.mean.%4yr", "all", "average", "none", 2
@@ -130,23 +130,11 @@ ACCESS-OM3
 "access-om3.mom6.2d.pbo.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
 "ocean_model", "pbo", "pbo", "access-om3.mom6.2d.pbo.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.2d.salt_flux_in.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
-"ocean_model", "salt_flux_in", "salt_flux_in", "access-om3.mom6.2d.salt_flux_in.1mon.mean.%4yr", "all", "average", "none", 2
-
-"access-om3.mom6.2d.tnkebto.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
-"ocean_model", "tnkebto", "tnkebto", "access-om3.mom6.2d.tnkebto.1mon.mean.%4yr", "all", "average", "none", 2
-
 
 # monthly 2d max fields
 
 "access-om3.mom6.2d.mlotst.1mon.max.%4yr", 1, "months", 1, "days", "time", 1, "years"
 "ocean_model", "mlotst", "mlotst", "access-om3.mom6.2d.mlotst.1mon.max.%4yr", "all", "max", "none", 2
-
-
-# monthly 2d min fields
-
-"access-om3.mom6.2d.mlotst.1mon.min.%4yr", 1, "months", 1, "days", "time", 1, "years"
-"ocean_model", "mlotst", "mlotst", "access-om3.mom6.2d.mlotst.1mon.min.%4yr", "all", "min", "none", 2
 
 
 # daily 2D fields

--- a/diagnostic_profiles/source_yaml_files/diag_table_standard_source.yaml
+++ b/diagnostic_profiles/source_yaml_files/diag_table_standard_source.yaml
@@ -202,29 +202,20 @@ diag_table:
             pso: # Pressure at ice-ocean or atmosphere-ocean interface p_surf
             sfdsi: # Net salt flux into ocean at surface (restoring + sea-ice) salt_flux
             salt_flux_added: # Salt flux into ocean at surface due to restoring or flux adjustment
-            Rd_dx: # Ratio between deformation radius and grid spacing
             mlotst: # Mixed layer depth (delta rho = 0.03) MLD_003
             speed: # Sea Surface Speed
-            SSH: # Sea Surface Height
+            zos: # Sea surface height above geoid
+            zossq: # Square of sea surface height above geoid
             tauuo: # surface_downward_x_stress taux
             tauvo: # surface_downward_y_stress tauy
             umo_2d: # Ocean Mass X Transport Vertical Sum
             vmo_2d: # Ocean Mass Y Transport Vertical Sum
             pbo: # Sea Water Pressure at Sea Floor
-            salt_flux_in: # Salt flux into ocean at surface from coupler
-            tnkebto: # Integrated Tendency of Ocean Mesoscale Eddy KE from Parameterized Eddy Advection GMwork
 
     'monthly 2d max fields':
         defaults:  # these can be overridden for individual fields below
             file_name_dimension: 2d  # descriptor for filename, e.g. 3d, 2d, scalar
             reduction_method: max  # mean, snap, rms, pow##, min, max, or diurnal##
-        fields:
-            mlotst: # Mixed layer depth (delta rho = 0.03) MLD_003
-
-    'monthly 2d min fields':
-        defaults:  # these can be overridden for individual fields below
-            file_name_dimension: 2d  # descriptor for filename, e.g. 3d, 2d, scalar
-            reduction_method: min  # mean, snap, rms, pow##, min, max, or diurnal##
         fields:
             mlotst: # Mixed layer depth (delta rho = 0.03) MLD_003
 

--- a/diagnostic_profiles/source_yaml_files/diag_table_standard_source.yaml
+++ b/diagnostic_profiles/source_yaml_files/diag_table_standard_source.yaml
@@ -33,6 +33,7 @@ global_defaults:
         - file_name_prefix
         - file_name_dimension
         - field_name  # substituted by field name in diag_table section below
+        - z_coord
         - output_freq
         - '':
             - output_freq_units
@@ -86,6 +87,7 @@ global_defaults:
         average: mean
         'True': mean
         None: ""  # for empty items
+    z_coord: ""
 # %yr, %mo, %dy, %hr %mi, %sc are expanded to the current year, month, day, hour, minute and second respectively,
 
 #######################################################################################################
@@ -161,24 +163,31 @@ diag_table:
             dyCuo: # Open meridional grid spacing at u points (meter)
             dxCvo: # Open zonal grid spacing at v points (meter)
 
-    'monthly 3d fields':
+    'monthly 3d fields on z':
         defaults:  # these can be overridden for individual fields below
             file_name_dimension: 3d  # descriptor for filename, e.g. 3d, 2d, scalar
             reduction_method: mean
+            module_name: ocean_model_z
+            z_coord: "z"
         fields:
-            h: # Layer Thickness
             agessc: # Sea water age since surface contact
             rhopot2: # Potential density referenced to 2000 dbar
             thetao: # Potential Temperature
             so: # Salinity
             uo: # u velocity
             vo: # v velocity
-            uh: # Zonal Thickness Flux
-            vh: # Meridional Thickness Flux
-            uhGM: # Time Mean Diffusive Zonal Thickness Flux
-            vhGM: # Time Mean Diffusive Meridional Thickness Flux
-            thkcello: # Cell Thickness
             KE: # Layer Kinetic energy per unit mass
+
+    'monthly 3d fields on rho2':
+        defaults:  # these can be overridden for individual fields below
+            file_name_dimension: 3d  # descriptor for filename, e.g. 3d, 2d, scalar
+            reduction_method: mean
+            module_name: ocean_model_rho2
+            z_coord: "rho2"
+        fields:  # comment out all of these if not needed, as remapping to density slows model by ~30% - see https://github.com/ACCESS-NRI/access-om3-configs/pull/622#issuecomment-3031962668
+            e: # Interface height relative to mean sea level
+            umo: # Ocean Mass X Transport
+            vmo: # Ocean Mass Y Transport
 
     'monthly 2d fields':
         defaults:  # these can be overridden for individual fields below

--- a/docs/MOM_parameter_doc.all
+++ b/docs/MOM_parameter_doc.all
@@ -658,7 +658,7 @@ SPONGE = False                  !   [Boolean] default = False
                                 ! properties of those sponges are specified via SPONGE_CONFIG.
 
 ! === module MOM_diag_mediator ===
-NUM_DIAG_COORDS = 1             ! default = 1
+NUM_DIAG_COORDS = 2             ! default = 1
                                 ! The number of diagnostic vertical coordinates to use. For each coordinate, an
                                 ! entry in DIAG_COORDS must be provided.
 DIAG_REMAPPING_USE_OM4_SUBCELLS = False !   [Boolean] default = True
@@ -667,10 +667,10 @@ DIAG_REMAPPING_USE_OM4_SUBCELLS = False !   [Boolean] default = True
                                 ! false.
 USE_INDEX_DIAGNOSTIC_AXES = False !   [Boolean] default = False
                                 ! If true, use a grid index coordinate convention for diagnostic axes.
-DIAG_COORDS = "z Z ZSTAR"       ! default = "z Z ZSTAR"
+DIAG_COORDS = "z Z ZSTAR", "rho2 RHO2 RHO" !
                                 ! A list of string tuples associating diag_table modules to a coordinate
-                                ! definition used for diagnostics. Each string is of the form "MODULE_SUFFIX
-                                ! PARAMETER_SUFFIX COORDINATE_NAME".
+                                ! definition used for diagnostics. Each string is of the form
+                                ! "MODULE_SUFFIX,PARAMETER_SUFFIX,COORDINATE_NAME".
 DIAG_MISVAL = 1.0E+20           !   [various] default = 1.0E+20
                                 ! Set the default missing value to use for diagnostics.
 DIAG_AS_CHKSUM = False          !   [Boolean] default = False
@@ -695,6 +695,50 @@ DIAG_COORD_DEF_Z = "FILE:ocean_vgrid.nc,interfaces=zeta" ! default = "WOA09"
                                 !                the filename and two variable names, separated
                                 !                by a comma or space, for sigma-2 and dz. e.g.
                                 !                HYBRID:vgrid.nc,sigma2,dz
+DIAG_COORD_INTERP_SCHEME_RHO2 = "PPM_H4" ! default = "PPM_H4"
+                                ! This sets the interpolation scheme to use to determine the new grid. These
+                                ! parameters are only relevant when REGRIDDING_COORDINATE_MODE is set to a
+                                ! function of state. Otherwise, it is not used. It can be one of the following
+                                ! schemes:
+                                !  P1M_H2     (2nd-order accurate)
+                                !  P1M_H4     (2nd-order accurate)
+                                !  P1M_IH4    (2nd-order accurate)
+                                !  PLM        (2nd-order accurate)
+                                !  PPM_CW     (3rd-order accurate)
+                                !  PPM_H4     (3rd-order accurate)
+                                !  PPM_IH4    (3rd-order accurate)
+                                !  P3M_IH4IH3 (4th-order accurate)
+                                !  P3M_IH6IH5 (4th-order accurate)
+                                !  PQM_IH4IH3 (4th-order accurate)
+                                !  PQM_IH6IH5 (5th-order accurate)
+REGRIDDING_ANSWER_DATE = 99991231 ! default = 20181231
+                                ! The vintage of the expressions and order of arithmetic to use for regridding.
+                                ! Values below 20190101 result in the use of older, less accurate expressions
+                                ! that were in use at the end of 2018.  Higher values result in the use of more
+                                ! robust and accurate forms of mathematically equivalent expressions.
+DIAG_COORD_DEF_RHO2 = "RFNC1:76,999.5,1020.,1034.1,3.1,1041.,0.002" ! default = "WOA09"
+                                ! Determines how to specify the coordinate resolution. Valid options are:
+                                !  PARAM       - use the vector-parameter DIAG_COORD_RES_RHO2
+                                !  UNIFORM[:N] - uniformly distributed
+                                !  FILE:string - read from a file. The string specifies
+                                !                the filename and variable name, separated
+                                !                by a comma or space, e.g. FILE:lev.nc,dz
+                                !                or FILE:lev.nc,interfaces=zw
+                                !  WOA09[:N]   - the WOA09 vertical grid (approximately)
+                                !  WOA09INT[:N] - layers spanned by the WOA09 depths
+                                !  WOA23INT[:N] - layers spanned by the WOA23 depths
+                                !  FNC1:string - FNC1:dz_min,H_total,power,precision
+                                !  HYBRID:string - read from a file. The string specifies
+                                !                the filename and two variable names, separated
+                                !                by a comma or space, for sigma-2 and dz. e.g.
+                                !                HYBRID:vgrid.nc,sigma2,dz
+DIAG_COORD_P_REF_RHO2 = 2.0E+07 !   [Pa] default = 2.0E+07
+                                ! The pressure that is used for calculating the diagnostic coordinate density.
+                                ! (1 Pa = 1e4 dbar, so 2e7 is commonly used.) This is only used for the RHO
+                                ! coordinate.
+DIAG_COORD_REGRID_COMPRESSIBILITY_FRACTION_RHO2 = 0.0 !   [nondim] default = 0.0
+                                ! When interpolating potential density profiles we can add some artificial
+                                ! compressibility solely to make homogeneous regions appear stratified.
 
 ! === module MOM_MEKE ===
 USE_MEKE = True                 !   [Boolean] default = False

--- a/docs/MOM_parameter_doc.short
+++ b/docs/MOM_parameter_doc.short
@@ -216,13 +216,41 @@ Z_INIT_REMAPPING_USE_OM4_SUBCELLS = False !   [Boolean] default = True
                                 ! to false.
 
 ! === module MOM_diag_mediator ===
+NUM_DIAG_COORDS = 2             ! default = 1
+                                ! The number of diagnostic vertical coordinates to use. For each coordinate, an
+                                ! entry in DIAG_COORDS must be provided.
 DIAG_REMAPPING_USE_OM4_SUBCELLS = False !   [Boolean] default = True
                                 ! If true, use the OM4 remapping-via-subcells algorithm for diagnostics. See
                                 ! REMAPPING_USE_OM4_SUBCELLS for details. We recommend setting this option to
                                 ! false.
+DIAG_COORDS = "z Z ZSTAR", "rho2 RHO2 RHO" !
+                                ! A list of string tuples associating diag_table modules to a coordinate
+                                ! definition used for diagnostics. Each string is of the form
+                                ! "MODULE_SUFFIX,PARAMETER_SUFFIX,COORDINATE_NAME".
 DIAG_COORD_DEF_Z = "FILE:ocean_vgrid.nc,interfaces=zeta" ! default = "WOA09"
                                 ! Determines how to specify the coordinate resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter DIAG_COORD_RES_Z
+                                !  UNIFORM[:N] - uniformly distributed
+                                !  FILE:string - read from a file. The string specifies
+                                !                the filename and variable name, separated
+                                !                by a comma or space, e.g. FILE:lev.nc,dz
+                                !                or FILE:lev.nc,interfaces=zw
+                                !  WOA09[:N]   - the WOA09 vertical grid (approximately)
+                                !  WOA09INT[:N] - layers spanned by the WOA09 depths
+                                !  WOA23INT[:N] - layers spanned by the WOA23 depths
+                                !  FNC1:string - FNC1:dz_min,H_total,power,precision
+                                !  HYBRID:string - read from a file. The string specifies
+                                !                the filename and two variable names, separated
+                                !                by a comma or space, for sigma-2 and dz. e.g.
+                                !                HYBRID:vgrid.nc,sigma2,dz
+REGRIDDING_ANSWER_DATE = 99991231 ! default = 20181231
+                                ! The vintage of the expressions and order of arithmetic to use for regridding.
+                                ! Values below 20190101 result in the use of older, less accurate expressions
+                                ! that were in use at the end of 2018.  Higher values result in the use of more
+                                ! robust and accurate forms of mathematically equivalent expressions.
+DIAG_COORD_DEF_RHO2 = "RFNC1:76,999.5,1020.,1034.1,3.1,1041.,0.002" ! default = "WOA09"
+                                ! Determines how to specify the coordinate resolution. Valid options are:
+                                !  PARAM       - use the vector-parameter DIAG_COORD_RES_RHO2
                                 !  UNIFORM[:N] - uniformly distributed
                                 !  FILE:string - read from a file. The string specifies
                                 !                the filename and variable name, separated

--- a/docs/available_diags.000000
+++ b/docs/available_diags.000000
@@ -1,5 +1,5 @@
 "volcello"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Ocean grid-cell volume
     ! units: m3
     ! standard_name: ocean_volume
@@ -274,19 +274,19 @@
     ! units: m2
     ! cell_methods: xh:mean yq:point
 "sqg_struct"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Vertical structure of SQG mode
     ! units: nondim
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {sqg_struct,sqg_struct_xyave}
 "N2_u"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Square of Brunt-Vaisala frequency, N^2, at u-points, as used in Visbeck et al.
     ! units: s-2
     ! cell_methods: xq:point yh:mean zi:point
     ! variants: {N2_u,N2_u_xyave}
 "N2_v"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Square of Brunt-Vaisala frequency, N^2, at v-points, as used in Visbeck et al.
     ! units: s-2
     ! cell_methods: xh:mean yq:point zi:point
@@ -342,25 +342,25 @@
     ! units: m s-1
     ! cell_methods: xh:mean yq:point
 "Rayleigh_u"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Rayleigh drag velocity at u points
     ! units: m s-1
     ! cell_methods: xq:point yh:mean zl:mean
     ! variants: {Rayleigh_u,Rayleigh_u_xyave}
 "Rayleigh_v"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Rayleigh drag velocity at v points
     ! units: m s-1
     ! cell_methods: xh:mean yq:point zl:mean
     ! variants: {Rayleigh_v,Rayleigh_v_xyave}
-"uhGM"  [Used]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+"uhGM"  [Unused]
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Time Mean Diffusive Zonal Thickness Flux
     ! units: kg s-1
     ! cell_methods: xq:point yh:sum zl:sum
     ! variants: {uhGM,uhGM_xyave}
-"vhGM"  [Used]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+"vhGM"  [Unused]
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Time Mean Diffusive Meridional Thickness Flux
     ! units: kg s-1
     ! cell_methods: xh:sum yq:point zl:sum
@@ -372,19 +372,19 @@
     ! cell_methods: xh:mean yh:mean area:mean
     ! variants: {GMwork,tnkebto}
 "KHTH_u"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Parameterized mesoscale eddy advection diffusivity at U-point
     ! units: m2 s-1
     ! cell_methods: xq:point yh:mean zi:point
     ! variants: {KHTH_u,KHTH_u_xyave}
 "KHTH_v"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Parameterized mesoscale eddy advection diffusivity at V-point
     ! units: m2 s-1
     ! cell_methods: xh:mean yq:point zi:point
     ! variants: {KHTH_v,KHTH_v_xyave}
 "KHTH_t"  [Unused] (CMOR equivalent is "diftrblo")
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Ocean Tracer Diffusivity due to Parameterized Mesoscale Advection
     ! units: m2 s-1
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
@@ -405,37 +405,37 @@
     ! units: m2 s-1
     ! cell_methods: xh:mean yh:mean area:mean
 "neutral_slope_x"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Zonal slope of neutral surface
     ! units: nondim
     ! cell_methods: xq:point yh:mean zi:point
     ! variants: {neutral_slope_x,neutral_slope_x_xyave}
 "neutral_slope_y"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Meridional slope of neutral surface
     ! units: nondim
     ! cell_methods: xh:mean yq:point zi:point
     ! variants: {neutral_slope_y,neutral_slope_y_xyave}
 "GM_sfn_x"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Parameterized Zonal Overturning Streamfunction
     ! units: m3 s-1
     ! cell_methods: xq:point yh:mean zi:point
     ! variants: {GM_sfn_x,GM_sfn_x_xyave}
 "GM_sfn_y"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Parameterized Meridional Overturning Streamfunction
     ! units: m3 s-1
     ! cell_methods: xh:mean yq:point zi:point
     ! variants: {GM_sfn_y,GM_sfn_y_xyave}
 "GM_sfn_unlim_x"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Parameterized Zonal Overturning Streamfunction before limiting/smoothing
     ! units: m3 s-1
     ! cell_methods: xq:point yh:mean zi:point
     ! variants: {GM_sfn_unlim_x,GM_sfn_unlim_x_xyave}
 "GM_sfn_unlim_y"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Parameterized Meridional Overturning Streamfunction before limiting/smoothing
     ! units: m3 s-1
     ! cell_methods: xh:mean yq:point zi:point
@@ -451,37 +451,37 @@
     ! units: m-1 s-1
     ! cell_methods: xq:point yq:point zl:mean
 "gKEu"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Zonal Acceleration from Grad. Kinetic Energy
     ! units: m s-2
     ! cell_methods: xq:point yh:mean zl:mean
     ! variants: {gKEu,gKEu_xyave}
 "gKEv"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Meridional Acceleration from Grad. Kinetic Energy
     ! units: m s-2
     ! cell_methods: xh:mean yq:point zl:mean
     ! variants: {gKEv,gKEv_xyave}
 "rvxu"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Meridional Acceleration from Relative Vorticity
     ! units: m s-2
     ! cell_methods: xh:mean yq:point zl:mean
     ! variants: {rvxu,rvxu_xyave}
 "rvxv"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Zonal Acceleration from Relative Vorticity
     ! units: m s-2
     ! cell_methods: xq:point yh:mean zl:mean
     ! variants: {rvxv,rvxv_xyave}
 "CAu_Stokes"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Zonal Acceleration from Stokes Vorticity
     ! units: m s-2
     ! cell_methods: xq:point yh:mean zl:mean
     ! variants: {CAu_Stokes,CAu_Stokes_xyave}
 "CAv_Stokes"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Meridional Acceleration from Stokes Vorticity
     ! units: m s-2
     ! cell_methods: xh:mean yq:point zl:mean
@@ -497,7 +497,7 @@
     ! units: m s-2
     ! cell_methods: xh:mean yq:point
 "h_gKEu"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Thickness Multiplied Zonal Acceleration from Grad. Kinetic Energy
     ! units: m2 s-2
     ! cell_methods: xq:point yh:mean zl:mean
@@ -508,7 +508,7 @@
     ! units: m2 s-2
     ! cell_methods: xq:point yh:mean
 "h_gKEv"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Thickness Multiplied Meridional Acceleration from Grad. Kinetic Energy
     ! units: m2 s-2
     ! cell_methods: xh:mean yq:point zl:mean
@@ -529,7 +529,7 @@
     ! units: m s-2
     ! cell_methods: xq:point yh:mean
 "h_rvxu"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Thickness Multiplied Meridional Acceleration from Relative Vorticity
     ! units: m2 s-2
     ! cell_methods: xh:mean yq:point zl:mean
@@ -540,7 +540,7 @@
     ! units: m2 s-2
     ! cell_methods: xh:mean yq:point
 "h_rvxv"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Thickness Multiplied Zonal Acceleration from Relative Vorticity
     ! units: m2 s-2
     ! cell_methods: xq:point yh:mean zl:mean
@@ -551,19 +551,19 @@
     ! units: m2 s-2
     ! cell_methods: xq:point yh:mean
 "MassWt_u"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: The fractional mass weighting at u-point PGF calculations
     ! units: nondim
     ! cell_methods: xq:point yh:mean zl:mean
     ! variants: {MassWt_u,MassWt_u_xyave}
 "MassWt_v"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: The fractional mass weighting at v-point PGF calculations
     ! units: nondim
     ! cell_methods: xh:mean yq:point zl:mean
     ! variants: {MassWt_v,MassWt_v_xyave}
 "NoSt"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Normal Stress
     ! units: s-1
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
@@ -574,13 +574,13 @@
     ! units: s-1
     ! cell_methods: xq:point yq:point zl:mean
 "diffu"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Zonal Acceleration from Horizontal Viscosity
     ! units: m s-2
     ! cell_methods: xq:point yh:mean zl:mean
     ! variants: {diffu,diffu_xyave}
 "diffv"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Meridional Acceleration from Horizontal Viscosity
     ! units: m s-2
     ! cell_methods: xh:mean yq:point zl:mean
@@ -596,13 +596,13 @@
     ! units: m s-2
     ! cell_methods: xh:mean yq:point
 "h_diffu"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Thickness Multiplied Zonal Acceleration from Horizontal Viscosity
     ! units: m2 s-2
     ! cell_methods: xq:point yh:mean zl:mean
     ! variants: {h_diffu,h_diffu_xyave}
 "h_diffv"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Thickness Multiplied Meridional Acceleration from Horizontal Viscosity
     ! units: m2 s-2
     ! cell_methods: xh:mean yq:point zl:mean
@@ -618,19 +618,19 @@
     ! units: m2 s-2
     ! cell_methods: xh:mean yq:point
 "diffu_visc_rem"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Zonal Acceleration from Horizontal Viscosity multiplied by viscous remnant
     ! units: m s-2
     ! cell_methods: xq:point yh:mean zl:mean
     ! variants: {diffu_visc_rem,diffu_visc_rem_xyave}
 "diffv_visc_rem"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Meridional Acceleration from Horizontal Viscosity multiplied by viscous remnant
     ! units: m s-2
     ! cell_methods: xh:mean yq:point zl:mean
     ! variants: {diffv_visc_rem,diffv_visc_rem_xyave}
 "Ahh"  [Unused] (CMOR equivalent is "difmxybo")
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Biharmonic Horizontal Viscosity at h Points
     ! units: m4 s-1
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
@@ -641,13 +641,13 @@
     ! units: m4 s-1
     ! cell_methods: xq:point yq:point zl:mean
 "grid_Re_Ah"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Grid Reynolds number for the Biharmonic horizontal viscosity at h points
     ! units: nondim
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {grid_Re_Ah,grid_Re_Ah_xyave}
 "Khh"  [Unused] (CMOR equivalent is "difmxylo")
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Laplacian Horizontal Viscosity at h Points
     ! units: m2 s-1
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
@@ -658,7 +658,7 @@
     ! units: m2 s-1
     ! cell_methods: xq:point yq:point zl:mean
 "grid_Re_Kh"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Grid Reynolds number for the Laplacian horizontal viscosity at h points
     ! units: nondim
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
@@ -669,7 +669,7 @@
     ! units: s-1
     ! cell_methods: xq:point yq:point zl:mean
 "div_xx_h"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Horizontal divergence at h Points
     ! units: s-1
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
@@ -680,13 +680,13 @@
     ! units: s-1
     ! cell_methods: xq:point yq:point zl:mean
 "sh_xx_h"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Horizontal tension at h Points
     ! units: s-1
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {sh_xx_h,sh_xx_h_xyave}
 "FrictWork"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Integral work done by lateral friction terms. If GME is turned on, this includes the GME contribution.
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
@@ -698,7 +698,7 @@
     ! cell_methods: xh:mean yh:mean area:mean
     ! variants: {FrictWorkIntz,dispkexyfo}
 "FrictWork_bh"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Integral work done by the biharmonic lateral friction terms.
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
@@ -709,67 +709,67 @@
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
 "Kv_slow"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Slow varying vertical viscosity
     ! units: m2 s-1
     ! cell_methods: xh:mean yh:mean zi:point area:mean
     ! variants: {Kv_slow,Kv_slow_xyave}
 "Kv_u"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Total vertical viscosity at u-points
     ! units: m2 s-1
     ! cell_methods: xq:point yh:mean zl:mean
     ! variants: {Kv_u,Kv_u_xyave}
 "Kv_v"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Total vertical viscosity at v-points
     ! units: m2 s-1
     ! cell_methods: xh:mean yq:point zl:mean
     ! variants: {Kv_v,Kv_v_xyave}
 "Kv_gl90_u"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: GL90 vertical viscosity at u-points
     ! units: m2 s-1
     ! cell_methods: xq:point yh:mean zl:mean
     ! variants: {Kv_gl90_u,Kv_gl90_u_xyave}
 "Kv_gl90_v"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: GL90 vertical viscosity at v-points
     ! units: m2 s-1
     ! cell_methods: xh:mean yq:point zl:mean
     ! variants: {Kv_gl90_v,Kv_gl90_v_xyave}
 "au_visc"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Zonal Viscous Vertical Coupling Coefficient
     ! units: m s-1
     ! cell_methods: xq:point yh:mean zi:point
     ! variants: {au_visc,au_visc_xyave}
 "av_visc"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Meridional Viscous Vertical Coupling Coefficient
     ! units: m s-1
     ! cell_methods: xh:mean yq:point zi:point
     ! variants: {av_visc,av_visc_xyave}
 "au_gl90_visc"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Zonal Viscous Vertical GL90 Coupling Coefficient
     ! units: m s-1
     ! cell_methods: xq:point yh:mean zi:point
     ! variants: {au_gl90_visc,au_gl90_visc_xyave}
 "av_gl90_visc"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Meridional Viscous Vertical GL90 Coupling Coefficient
     ! units: m s-1
     ! cell_methods: xh:mean yq:point zi:point
     ! variants: {av_gl90_visc,av_gl90_visc_xyave}
 "Hu_visc"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Thickness at Zonal Velocity Points for Viscosity
     ! units: m
     ! cell_methods: xq:point yh:mean zl:mean
     ! variants: {Hu_visc,Hu_visc_xyave}
 "Hv_visc"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Thickness at Meridional Velocity Points for Viscosity
     ! units: m
     ! cell_methods: xh:mean yq:point zl:mean
@@ -790,79 +790,79 @@
     ! units: radians
     ! cell_methods: xh:mean yh:mean area:mean
 "tauFP_u"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Stress Mag Profile  (u-points)
     ! units: m2 s-2
     ! cell_methods: xq:point yh:mean zi:point
     ! variants: {tauFP_u,tauFP_u_xyave}
 "tauFP_v"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Stress Mag Profile  (v-points)
     ! units: m2 s-2
     ! cell_methods: xh:mean yq:point zi:point
     ! variants: {tauFP_v,tauFP_v_xyave}
 "FPtau2s_u"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: stress from shear direction (u-points)
     ! units: radians
     ! cell_methods: xq:point yh:mean zi:point
     ! variants: {FPtau2s_u,FPtau2s_u_xyave}
 "FPtau2s_v"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: stress from shear direction (v-points)
     ! units: radians
     ! cell_methods: xh:mean yq:point zi:point
     ! variants: {FPtau2s_v,FPtau2s_v_xyave}
 "FPtau2w_u"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: stress from wind  direction (u-points)
     ! units: radians
     ! cell_methods: xq:point yh:mean zi:point
     ! variants: {FPtau2w_u,FPtau2w_u_xyave}
 "FPtau2w_v"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: stress from wind  direction (v-points)
     ! units: radians
     ! cell_methods: xh:mean yq:point zi:point
     ! variants: {FPtau2w_v,FPtau2w_v_xyave}
 "du_dt_visc"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Zonal Acceleration from Vertical Viscosity
     ! units: m s-2
     ! cell_methods: xq:point yh:mean zl:mean
     ! variants: {du_dt_visc,du_dt_visc_xyave}
 "dv_dt_visc"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Meridional Acceleration from Vertical Viscosity
     ! units: m s-2
     ! cell_methods: xh:mean yq:point zl:mean
     ! variants: {dv_dt_visc,dv_dt_visc_xyave}
 "GLwork"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Sign-definite Kinetic Energy Source from GL90 Vertical Viscosity
     ! units: m3 s-3
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {GLwork,GLwork_xyave}
 "du_dt_visc_gl90"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Zonal Acceleration from GL90 Vertical Viscosity
     ! units: m s-2
     ! cell_methods: xq:point yh:mean zl:mean
     ! variants: {du_dt_visc_gl90,du_dt_visc_gl90_xyave}
 "dv_dt_visc_gl90"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Meridional Acceleration from GL90 Vertical Viscosity
     ! units: m s-2
     ! cell_methods: xh:mean yq:point zl:mean
     ! variants: {dv_dt_visc_gl90,dv_dt_visc_gl90_xyave}
 "du_dt_str"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Zonal Acceleration from Surface Wind Stresses
     ! units: m s-2
     ! cell_methods: xq:point yh:mean zl:mean
     ! variants: {du_dt_str,du_dt_str_xyave}
 "dv_dt_str"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Meridional Acceleration from Surface Wind Stresses
     ! units: m s-2
     ! cell_methods: xh:mean yq:point zl:mean
@@ -888,37 +888,37 @@
     ! units: m s-2
     ! cell_methods: xh:mean yq:point
 "h_du_dt_visc"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Thickness Multiplied Zonal Acceleration from Horizontal Viscosity
     ! units: m2 s-2
     ! cell_methods: xq:point yh:mean zl:mean
     ! variants: {h_du_dt_visc,h_du_dt_visc_xyave}
 "h_dv_dt_visc"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Thickness Multiplied Meridional Acceleration from Horizontal Viscosity
     ! units: m2 s-2
     ! cell_methods: xh:mean yq:point zl:mean
     ! variants: {h_dv_dt_visc,h_dv_dt_visc_xyave}
 "h_du_dt_str"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Thickness Multiplied Zonal Acceleration from Surface Wind Stresses
     ! units: m2 s-2
     ! cell_methods: xq:point yh:mean zl:mean
     ! variants: {h_du_dt_str,h_du_dt_str_xyave}
 "h_dv_dt_str"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Thickness Multiplied Meridional Acceleration from Surface Wind Stresses
     ! units: m2 s-2
     ! cell_methods: xh:mean yq:point zl:mean
     ! variants: {h_dv_dt_str,h_dv_dt_str_xyave}
 "du_dt_str_visc_rem"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Zonal Acceleration from Surface Wind Stresses multiplied by viscous remnant
     ! units: m s-2
     ! cell_methods: xq:point yh:mean zl:mean
     ! variants: {du_dt_str_visc_rem,du_dt_str_visc_rem_xyave}
 "dv_dt_str_visc_rem"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Meridional Acceleration from Surface Wind Stresses multiplied by viscous remnant
     ! units: m s-2
     ! cell_methods: xh:mean yq:point zl:mean
@@ -1019,13 +1019,13 @@
     ! units: m
     ! cell_methods: xh:mean yh:mean area:mean
 "visc_rem_u"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Viscous remnant at u
     ! units: nondim
     ! cell_methods: xq:point yh:mean zl:mean
     ! variants: {visc_rem_u,visc_rem_u_xyave}
 "visc_rem_v"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Viscous remnant at v
     ! units: nondim
     ! cell_methods: xh:mean yq:point zl:mean
@@ -1081,25 +1081,25 @@
     ! units: m3 s-1
     ! cell_methods: xh:mean yq:point
 "frhatu"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Fractional thickness of layers in u-columns
     ! units: nondim
     ! cell_methods: xq:point yh:mean zl:mean
     ! variants: {frhatu,frhatu_xyave}
 "frhatv"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Fractional thickness of layers in v-columns
     ! units: nondim
     ! cell_methods: xh:mean yq:point zl:mean
     ! variants: {frhatv,frhatv_xyave}
 "frhatu1"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Predictor Fractional thickness of layers in u-columns
     ! units: nondim
     ! cell_methods: xq:point yh:mean zl:mean
     ! variants: {frhatu1,frhatu1_xyave}
 "frhatv1"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Predictor Fractional thickness of layers in v-columns
     ! units: nondim
     ! cell_methods: xh:mean yq:point zl:mean
@@ -1184,50 +1184,50 @@
     ! long_name: Barotropic meridional transport difference
     ! units: m3 s-1
     ! cell_methods: xh:mean yq:point
-"uh"  [Used]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+"uh"  [Unused]
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Zonal Thickness Flux
     ! units: m3 s-1
     ! cell_methods: xq:point yh:sum zl:sum
     ! variants: {uh,uh_xyave}
-"vh"  [Used]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+"vh"  [Unused]
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Meridional Thickness Flux
     ! units: m3 s-1
     ! cell_methods: xh:sum yq:point zl:sum
     ! variants: {vh,vh_xyave}
 "CAu"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Zonal Coriolis and Advective Acceleration
     ! units: m s-2
     ! cell_methods: xq:point yh:mean zl:mean
     ! variants: {CAu,CAu_xyave}
 "CAv"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Meridional Coriolis and Advective Acceleration
     ! units: m s-2
     ! cell_methods: xh:mean yq:point zl:mean
     ! variants: {CAv,CAv_xyave}
 "PFu"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Zonal Pressure Force Acceleration
     ! units: m s-2
     ! cell_methods: xq:point yh:mean zl:mean
     ! variants: {PFu,PFu_xyave}
 "PFv"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Meridional Pressure Force Acceleration
     ! units: m s-2
     ! cell_methods: xh:mean yq:point zl:mean
     ! variants: {PFv,PFv_xyave}
 "ueffA"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Effective U-Face Area
     ! units: m^2
     ! cell_methods: xq:point yh:sum zl:sum
     ! variants: {ueffA,ueffA_xyave}
 "veffA"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Effective V-Face Area
     ! units: m^2
     ! cell_methods: xh:sum yq:point zl:sum
@@ -1248,13 +1248,13 @@
     ! units: m s-2
     ! cell_methods: xh:mean yq:point
 "h_PFu"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Thickness Multiplied Zonal Pressure Force Acceleration
     ! units: m2 s-2
     ! cell_methods: xq:point yh:mean zl:mean
     ! variants: {h_PFu,h_PFu_xyave}
 "h_PFv"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Thickness Multiplied Meridional Pressure Force Acceleration
     ! units: m2 s-2
     ! cell_methods: xh:mean yq:point zl:mean
@@ -1280,13 +1280,13 @@
     ! units: m s-2
     ! cell_methods: xh:mean yq:point
 "h_CAu"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Thickness Multiplied Zonal Coriolis and Advective Acceleration
     ! units: m2 s-2
     ! cell_methods: xq:point yh:mean zl:mean
     ! variants: {h_CAu,h_CAu_xyave}
 "h_CAv"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Thickness Multiplied Meridional Coriolis and Advective Acceleration
     ! units: m2 s-2
     ! cell_methods: xh:mean yq:point zl:mean
@@ -1302,25 +1302,25 @@
     ! units: m2 s-2
     ! cell_methods: xh:mean yq:point
 "uav"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Barotropic-step Averaged Zonal Velocity
     ! units: m s-1
     ! cell_methods: xq:point yh:mean zl:mean
     ! variants: {uav,uav_xyave}
 "vav"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Barotropic-step Averaged Meridional Velocity
     ! units: m s-1
     ! cell_methods: xh:mean yq:point zl:mean
     ! variants: {vav,vav_xyave}
 "u_BT_accel"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Barotropic Anomaly Zonal Acceleration
     ! units: m s-2
     ! cell_methods: xq:point yh:mean zl:mean
     ! variants: {u_BT_accel,u_BT_accel_xyave}
 "v_BT_accel"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Barotropic Anomaly Meridional Acceleration
     ! units: m s-2
     ! cell_methods: xh:mean yq:point zl:mean
@@ -1336,13 +1336,13 @@
     ! units: m s-2
     ! cell_methods: xh:mean yq:point
 "h_u_BT_accel"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Thickness Multiplied Barotropic Anomaly Zonal Acceleration
     ! units: m2 s-2
     ! cell_methods: xq:point yh:mean zl:mean
     ! variants: {h_u_BT_accel,h_u_BT_accel_xyave}
 "h_v_BT_accel"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Thickness Multiplied Barotropic Anomaly Meridional Acceleration
     ! units: m2 s-2
     ! cell_methods: xh:mean yq:point zl:mean
@@ -1358,49 +1358,49 @@
     ! units: m2 s-2
     ! cell_methods: xh:mean yq:point
 "PFu_visc_rem"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Zonal Pressure Force Acceleration multiplied by the viscous remnant
     ! units: m s-2
     ! cell_methods: xq:point yh:mean zl:mean
     ! variants: {PFu_visc_rem,PFu_visc_rem_xyave}
 "PFv_visc_rem"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Meridional Pressure Force Acceleration multiplied by the viscous remnant
     ! units: m s-2
     ! cell_methods: xh:mean yq:point zl:mean
     ! variants: {PFv_visc_rem,PFv_visc_rem_xyave}
 "CAu_visc_rem"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Zonal Coriolis and Advective Acceleration multiplied by the viscous remnant
     ! units: m s-2
     ! cell_methods: xq:point yh:mean zl:mean
     ! variants: {CAu_visc_rem,CAu_visc_rem_xyave}
 "CAv_visc_rem"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Meridional Coriolis and Advective Acceleration multiplied by the viscous remnant
     ! units: m s-2
     ! cell_methods: xh:mean yq:point zl:mean
     ! variants: {CAv_visc_rem,CAv_visc_rem_xyave}
 "u_BT_accel_visc_rem"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Barotropic Anomaly Zonal Acceleration multiplied by the viscous remnant
     ! units: m s-2
     ! cell_methods: xq:point yh:mean zl:mean
     ! variants: {u_BT_accel_visc_rem,u_BT_accel_visc_rem_xyave}
 "v_BT_accel_visc_rem"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Barotropic Anomaly Meridional Acceleration multiplied by the viscous remnant
     ! units: m s-2
     ! cell_methods: xh:mean yq:point zl:mean
     ! variants: {v_BT_accel_visc_rem,v_BT_accel_visc_rem_xyave}
 "uhml"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Zonal Thickness Flux to Restratify Mixed Layer
     ! units: kg s-1
     ! cell_methods: xq:point yh:sum zl:sum
     ! variants: {uhml,uhml_xyave}
 "vhml"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Meridional Thickness Flux to Restratify Mixed Layer
     ! units: kg s-1
     ! cell_methods: xh:sum yq:point zl:sum
@@ -1471,7 +1471,7 @@
     ! units: m
     ! cell_methods: xh:mean yh:mean area:mean
 "masscello"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Mass per unit area of liquid ocean grid cell
     ! units: kg m-2
     ! standard_name: sea_water_mass_per_unit_area
@@ -1482,15 +1482,15 @@
     ! long_name: Mass of liquid ocean
     ! units: kg
     ! standard_name: sea_water_mass
-"thkcello"  [Used]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+"thkcello"  [Unused]
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Cell Thickness
     ! units: m
     ! standard_name: cell_thickness
     ! cell_methods: xh:mean yh:mean zl:sum area:mean
     ! variants: {thkcello,thkcello_xyave}
 "h_pre_sync"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Cell thickness from the previous timestep
     ! units: m
     ! cell_methods: xh:mean yh:mean zl:sum area:mean
@@ -1508,14 +1508,14 @@
     ! standard_name: sea_water_salinity_at_sea_floor
     ! cell_methods: xh:mean yh:mean area:mean
 "tosq"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Square of Potential Temperature
     ! units: degC2
     ! standard_name: Potential Temperature Squared
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {tosq,tosq_xyave}
 "sosq"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Square of Salinity
     ! units: psu2
     ! standard_name: Salinity Squared
@@ -1554,109 +1554,109 @@
     ! standard_name: sea_surface_salinity
     ! variants: {sss_global,sosga}
 "u"  [Used] (CMOR equivalent is "uo")
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Zonal velocity
     ! units: m s-1
     ! cell_methods: xq:point yh:mean zl:mean
     ! variants: {u,u_xyave,uo,uo_xyave}
 "v"  [Used] (CMOR equivalent is "vo")
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Meridional velocity
     ! units: m s-1
     ! cell_methods: xh:mean yq:point zl:mean
     ! variants: {v,v_xyave,vo,vo_xyave}
 "usq"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Zonal velocity squared
     ! units: m2 s-2
     ! cell_methods: xq:point yh:mean zl:mean
     ! variants: {usq,usq_xyave}
 "vsq"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Meridional velocity squared
     ! units: m2 s-2
     ! cell_methods: xh:mean yq:point zl:mean
     ! variants: {vsq,vsq_xyave}
 "uv"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Product between zonal and meridional velocities at h-points
     ! units: m2 s-2
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {uv,uv_xyave}
-"h"  [Used]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+"h"  [Unused]
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Layer Thickness
     ! units: m
     ! cell_methods: xh:mean yh:mean zl:sum area:mean
     ! variants: {h,h_xyave}
-"e"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+"e"  [Used]
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Interface Height Relative to Mean Sea Level
     ! units: m
     ! cell_methods: xh:mean yh:mean zi:point area:mean
     ! variants: {e,e_xyave}
 "e_D"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Interface Height above the Seafloor
     ! units: m
     ! cell_methods: xh:mean yh:mean zi:point area:mean
     ! variants: {e_D,e_D_xyave}
 "Rml"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Mixed Layer Coordinate Potential Density
     ! units: kg m-3
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {Rml,Rml_xyave}
 "Rho_cv"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Coordinate Potential Density
     ! units: kg m-3
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {Rho_cv,Rho_cv_xyave}
 "rhopot0"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Potential density referenced to surface
     ! units: kg m-3
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {rhopot0,rhopot0_xyave}
 "rhopot2"  [Used]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Potential density referenced to 2000 dbar
     ! units: kg m-3
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {rhopot2,rhopot2_xyave}
 "rhoinsitu"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: In situ density
     ! units: kg m-3
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {rhoinsitu,rhoinsitu_xyave}
 "drho_dT"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Partial derivative of rhoinsitu with respect to temperature (alpha)
     ! units: kg m-3 degC-1
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {drho_dT,drho_dT_xyave}
 "drho_dS"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Partial derivative of rhoinsitu with respect to salinity (beta)
     ! units: kg^2 g-1 m-3
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {drho_dS,drho_dS_xyave}
 "dudt"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Zonal Acceleration
     ! units: m s-2
     ! cell_methods: xq:point yh:mean zl:mean
     ! variants: {dudt,dudt_xyave}
 "dvdt"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Meridional Acceleration
     ! units: m s-2
     ! cell_methods: xh:mean yq:point zl:mean
     ! variants: {dvdt,dvdt_xyave}
 "dhdt"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Thickness tendency
     ! units: m s-1
     ! cell_methods: xh:mean yh:mean zl:sum area:mean
@@ -1672,109 +1672,109 @@
     ! units: m s-2
     ! cell_methods: xh:mean yq:point
 "h_du_dt"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Thickness Multiplied Zonal Acceleration
     ! units: m2 s-2
     ! cell_methods: xq:point yh:mean zl:mean
     ! variants: {h_du_dt,h_du_dt_xyave}
 "h_dv_dt"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Thickness Multiplied Meridional Acceleration
     ! units: m2 s-2
     ! cell_methods: xh:mean yq:point zl:mean
     ! variants: {h_dv_dt,h_dv_dt_xyave}
 "h_rho"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Layer thicknesses in pure potential density coordinates
     ! units: m
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {h_rho,h_rho_xyave}
 "uh_rho"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Zonal volume transport in pure potential density coordinates
     ! units: m3 s-1
     ! cell_methods: xq:point yh:mean zl:mean
     ! variants: {uh_rho,uh_rho_xyave}
 "vh_rho"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Meridional volume transport in pure potential density coordinates
     ! units: m3 s-1
     ! cell_methods: xh:mean yq:point zl:mean
     ! variants: {vh_rho,vh_rho_xyave}
 "uhGM_rho"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Zonal volume transport due to interface height diffusion in pure potential density coordinates
     ! units: m3 s-1
     ! cell_methods: xq:point yh:mean zl:mean
     ! variants: {uhGM_rho,uhGM_rho_xyave}
 "vhGM_rho"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Meridional volume transport due to interface height diffusion in pure potential density coordinates
     ! units: m3 s-1
     ! cell_methods: xh:mean yq:point zl:mean
     ! variants: {vhGM_rho,vhGM_rho_xyave}
 "KE"  [Used]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Layer kinetic energy per unit mass
     ! units: m2 s-2
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {KE,KE_xyave}
 "dKE_dt"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Kinetic Energy Tendency of Layer
     ! units: m3 s-3
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {dKE_dt,dKE_dt_xyave}
 "PE_to_KE"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Potential to Kinetic Energy Conversion of Layer
     ! units: m3 s-3
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {PE_to_KE,PE_to_KE_xyave}
 "KE_BT"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Barotropic contribution to Kinetic Energy
     ! units: m3 s-3
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {KE_BT,KE_BT_xyave}
 "KE_Coradv"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Kinetic Energy Source from Coriolis and Advection
     ! units: m3 s-3
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {KE_Coradv,KE_Coradv_xyave}
 "KE_adv"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Kinetic Energy Source from Advection
     ! units: m3 s-3
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {KE_adv,KE_adv_xyave}
 "KE_visc"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Kinetic Energy Source from Vertical Viscosity and Stresses
     ! units: m3 s-3
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {KE_visc,KE_visc_xyave}
 "KE_visc_gl90"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Kinetic Energy Source from GL90 Vertical Viscosity
     ! units: m3 s-3
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {KE_visc_gl90,KE_visc_gl90_xyave}
 "KE_stress"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Kinetic Energy Source from Surface Stresses or Body Wind Stress
     ! units: m3 s-3
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {KE_stress,KE_stress_xyave}
 "KE_horvisc"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Kinetic Energy Source from Horizontal Viscosity
     ! units: m3 s-3
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {KE_horvisc,KE_horvisc_xyave}
 "KE_dia"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Kinetic Energy Source from Diapycnal Diffusion
     ! units: m3 s-3
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
@@ -1815,7 +1815,7 @@
     ! units: m
     ! cell_methods: xh:mean yh:mean area:mean
 "p_ebt"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Equivalent barotropic modal strcuture
     ! units: nondim
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
@@ -1854,49 +1854,49 @@
     ! standard_name: sea_water_pressure_at_sea_floor
     ! cell_methods: xh:mean yh:mean area:mean
 "ea_t"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Layer (heat) entrainment from above per timestep
     ! units: m
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {ea_t,ea_t_xyave}
 "eb_t"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Layer (heat) entrainment from below per timestep
     ! units: m
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {eb_t,eb_t_xyave}
 "ea_s"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Layer (salt) entrainment from above per timestep
     ! units: m
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {ea_s,ea_s_xyave}
 "eb_s"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Layer (salt) entrainment from below per timestep
     ! units: m
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {eb_s,eb_s_xyave}
 "ea"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Layer entrainment from above per timestep
     ! units: m
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {ea,ea_xyave}
 "eb"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Layer entrainment from below per timestep
     ! units: m
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {eb,eb_xyave}
 "Tflx_dia_diff"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Diffusive diapycnal temperature flux across interfaces
     ! units: degC m s-1
     ! cell_methods: xh:mean yh:mean zi:point area:mean
     ! variants: {Tflx_dia_diff,Tflx_dia_diff_xyave}
 "Sflx_dia_diff"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Diffusive diapycnal salnity flux across interfaces
     ! units: psu m s-1
     ! cell_methods: xh:mean yh:mean zi:point area:mean
@@ -1954,91 +1954,91 @@
     ! units: kg/m3
     ! cell_methods: xh:mean yh:mean area:mean
 "u_predia"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Zonal velocity before diabatic forcing
     ! units: m s-1
     ! cell_methods: xq:point yh:mean zl:mean
     ! variants: {u_predia,u_predia_xyave}
 "v_predia"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Meridional velocity before diabatic forcing
     ! units: m s-1
     ! cell_methods: xh:mean yq:point zl:mean
     ! variants: {v_predia,v_predia_xyave}
 "h_predia"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Layer Thickness before diabatic forcing
     ! units: m
     ! cell_methods: xh:mean yh:mean zl:sum area:mean
     ! variants: {h_predia,h_predia_xyave}
 "e_predia"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Interface Heights before diabatic forcing
     ! units: m
     ! cell_methods: xh:mean yh:mean zi:point area:mean
     ! variants: {e_predia,e_predia_xyave}
 "temp_predia"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Potential Temperature
     ! units: degC
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {temp_predia,temp_predia_xyave}
 "salt_predia"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Salinity
     ! units: PSU
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {salt_predia,salt_predia_xyave}
 "Kd_interface"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Total diapycnal diffusivity at interfaces
     ! units: m2 s-1
     ! cell_methods: xh:mean yh:mean zi:point area:mean
     ! variants: {Kd_interface,Kd_interface_xyave}
 "Kd_ePBL"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: ePBL diapycnal diffusivity at interfaces
     ! units: m2 s-1
     ! cell_methods: xh:mean yh:mean zi:point area:mean
     ! variants: {Kd_ePBL,Kd_ePBL_xyave}
 "Kd_heat"  [Unused] (CMOR equivalent is "difvho")
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Total diapycnal diffusivity for heat at interfaces
     ! units: m2 s-1
     ! cell_methods: xh:mean yh:mean zi:point area:mean
     ! variants: {Kd_heat,Kd_heat_xyave,difvho,difvho_xyave}
 "Kd_salt"  [Unused] (CMOR equivalent is "difvso")
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Total diapycnal diffusivity for salt at interfaces
     ! units: m2 s-1
     ! cell_methods: xh:mean yh:mean zi:point area:mean
     ! variants: {Kd_salt,Kd_salt_xyave,difvso,difvso_xyave}
 "diabatic_diff_h"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Cell thickness used during diabatic diffusion
     ! units: m
     ! cell_methods: xh:mean yh:mean zl:sum area:mean
     ! variants: {diabatic_diff_h,diabatic_diff_h_xyave}
 "diabatic_diff_temp_tendency"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Diabatic diffusion temperature tendency
     ! units: degC s-1
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {diabatic_diff_temp_tendency,diabatic_diff_temp_tendency_xyave}
 "diabatic_diff_saln_tendency"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Diabatic diffusion salinity tendency
     ! units: psu s-1
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {diabatic_diff_saln_tendency,diabatic_diff_saln_tendency_xyave}
 "diabatic_heat_tendency"  [Unused] (CMOR equivalent is "opottempdiff")
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Diabatic diffusion heat tendency
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean zl:sum area:mean
     ! variants: {diabatic_heat_tendency,diabatic_heat_tendency_xyave,opottempdiff,opottempdiff_xyave}
 "diabatic_salt_tendency"  [Unused] (CMOR equivalent is "osaltdiff")
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Diabatic diffusion of salt tendency
     ! units: kg m-2 s-1
     ! cell_methods: xh:mean yh:mean zl:sum area:mean
@@ -2056,37 +2056,37 @@
     ! cell_methods: xh:mean yh:mean area:mean
     ! variants: {diabatic_salt_tendency_2d,osaltdiff_2d}
 "boundary_forcing_h"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Cell thickness after applying boundary forcing
     ! units: m
     ! cell_methods: xh:mean yh:mean zl:sum area:mean
     ! variants: {boundary_forcing_h,boundary_forcing_h_xyave}
 "boundary_forcing_h_tendency"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Cell thickness tendency due to boundary forcing
     ! units: m s-1
     ! cell_methods: xh:mean yh:mean zl:sum area:mean
     ! variants: {boundary_forcing_h_tendency,boundary_forcing_h_tendency_xyave}
 "boundary_forcing_temp_tendency"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Boundary forcing temperature tendency
     ! units: degC s-1
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {boundary_forcing_temp_tendency,boundary_forcing_temp_tendency_xyave}
 "boundary_forcing_saln_tendency"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Boundary forcing saln tendency
     ! units: psu s-1
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {boundary_forcing_saln_tendency,boundary_forcing_saln_tendency_xyave}
 "boundary_forcing_heat_tendency"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Boundary forcing heat tendency
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean zl:sum area:mean
     ! variants: {boundary_forcing_heat_tendency,boundary_forcing_heat_tendency_xyave}
 "boundary_forcing_salt_tendency"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Boundary forcing salt tendency
     ! units: kg m-2 s-1
     ! cell_methods: xh:mean yh:mean zl:sum area:mean
@@ -2102,20 +2102,20 @@
     ! units: kg m-2 s-1
     ! cell_methods: xh:mean yh:mean area:mean
 "frazil_h"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Cell Thickness
     ! units: m
     ! standard_name: cell_thickness
     ! cell_methods: xh:mean yh:mean zl:sum area:mean
     ! variants: {frazil_h,frazil_h_xyave}
 "frazil_temp_tendency"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Temperature tendency due to frazil formation
     ! units: degC s-1
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {frazil_temp_tendency,frazil_temp_tendency_xyave}
 "frazil_heat_tendency"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Heat tendency due to frazil formation
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean zl:sum area:mean
@@ -2126,7 +2126,7 @@
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
 "Kd_itides"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Internal Tide Driven Diffusivity
     ! units: m2 s-1
     ! cell_methods: xh:mean yh:mean zi:point area:mean
@@ -2142,19 +2142,19 @@
     ! units: s-1
     ! cell_methods: xh:mean yh:mean area:mean
 "Kd_lowmode"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Internal Tide Driven Diffusivity (from propagating low modes)
     ! units: m2 s-1
     ! cell_methods: xh:mean yh:mean zi:point area:mean
     ! variants: {Kd_lowmode,Kd_lowmode_xyave}
 "Fl_itides"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Vertical flux of tidal turbulent dissipation
     ! units: m3 s-3
     ! cell_methods: xh:mean yh:mean zi:point area:mean
     ! variants: {Fl_itides,Fl_itides_xyave}
 "Fl_lowmode"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Vertical flux of tidal turbulent dissipation (from propagating low modes)
     ! units: m3 s-3
     ! cell_methods: xh:mean yh:mean zi:point area:mean
@@ -2180,91 +2180,91 @@
     ! units: s-2
     ! cell_methods: xh:mean yh:mean area:mean
 "Kd_Itidal_Work"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Work done by Internal Tide Diapycnal Mixing
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {Kd_Itidal_Work,Kd_Itidal_Work_xyave}
 "Kd_Nikurashin_Work"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Work done by Nikurashin Lee Wave Drag Scheme
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {Kd_Nikurashin_Work,Kd_Nikurashin_Work_xyave}
 "Kd_Lowmode_Work"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Work done by Internal Tide Diapycnal Mixing (low modes)
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {Kd_Lowmode_Work,Kd_Lowmode_Work_xyave}
 "Kd_BBL"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Bottom Boundary Layer Diffusivity
     ! units: m2 s-1
     ! cell_methods: xh:mean yh:mean zi:point area:mean
     ! variants: {Kd_BBL,Kd_BBL_xyave}
 "Kd_bkgnd"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Background diffusivity added by MOM_bkgnd_mixing module
     ! units: m2/s
     ! cell_methods: xh:mean yh:mean zi:point area:mean
     ! variants: {Kd_bkgnd,Kd_bkgnd_xyave}
 "Kv_bkgnd"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Background viscosity added by MOM_bkgnd_mixing module
     ! units: m2/s
     ! cell_methods: xh:mean yh:mean zi:point area:mean
     ! variants: {Kv_bkgnd,Kv_bkgnd_xyave}
 "Kd_layer"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Diapycnal diffusivity of layers (as set)
     ! units: m2 s-1
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {Kd_layer,Kd_layer_xyave}
 "Kd_Work"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Work done by Diapycnal Mixing
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {Kd_Work,Kd_Work_xyave}
 "maxTKE"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Maximum layer TKE
     ! units: m3 s-3
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {maxTKE,maxTKE_xyave}
 "TKE_to_Kd"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Convert TKE to Kd
     ! units: s2 m
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {TKE_to_Kd,TKE_to_Kd_xyave}
 "N2"  [Unused] (CMOR equivalent is "obvfsq")
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Buoyancy frequency squared
     ! units: s-2
     ! cell_methods: xh:mean yh:mean zi:point area:mean
     ! variants: {N2,N2_xyave,obvfsq,obvfsq_xyave}
 "Kd_shear"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Shear-driven Diapycnal Diffusivity
     ! units: m2 s-1
     ! cell_methods: xh:mean yh:mean zi:point area:mean
     ! variants: {Kd_shear,Kd_shear_xyave}
 "TKE_shear"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Shear-driven Turbulent Kinetic Energy
     ! units: m2 s-2
     ! cell_methods: xh:mean yh:mean zi:point area:mean
     ! variants: {TKE_shear,TKE_shear_xyave}
 "KT_extra"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Double-diffusive diffusivity for temperature
     ! units: m2 s-1
     ! cell_methods: xh:mean yh:mean zi:point area:mean
     ! variants: {KT_extra,KT_extra_xyave}
 "KS_extra"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Double-diffusive diffusivity for salinity
     ! units: m2 s-1
     ! cell_methods: xh:mean yh:mean zi:point area:mean
@@ -2275,14 +2275,14 @@
     ! units: m s-1
     ! cell_methods: xh:mean yh:mean area:mean
 "rsdoabsorb"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Convergence of Penetrative Shortwave Flux in Sea Water Layer
     ! units: W m-2
     ! standard_name: net_rate_of_absorption_of_shortwave_energy_in_ocean_layer
     ! cell_methods: xh:mean yh:mean zl:sum area:mean
     ! variants: {rsdoabsorb,rsdoabsorb_xyave}
 "rsdo"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Downwelling Shortwave Flux in Sea Water at Grid Cell Upper Interface
     ! units: W m-2
     ! standard_name: downwelling_shortwave_flux_in_sea_water
@@ -2340,13 +2340,13 @@
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
 "Mixing_Length"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Mixing Length that is used
     ! units: m
     ! cell_methods: xh:mean yh:mean zi:point area:mean
     ! variants: {Mixing_Length,Mixing_Length_xyave}
 "Velocity_Scale"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Velocity Scale that is used.
     ! units: m s-1
     ! cell_methods: xh:mean yh:mean zi:point area:mean
@@ -2382,25 +2382,25 @@
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
 "opac_1"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Opacity for shortwave radiation in band 1, saved as L^-1 tanh(Opacity * L) for L = 10^-10 m
     ! units: m-1
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {opac_1,opac_1_xyave}
 "KHTR_u"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Epipycnal tracer diffusivity at zonal faces of tracer cell
     ! units: m2 s-1
     ! cell_methods: xq:point yh:mean zi:point
     ! variants: {KHTR_u,KHTR_u_xyave}
 "KHTR_v"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Epipycnal tracer diffusivity at meridional faces of tracer cell
     ! units: m2 s-1
     ! cell_methods: xh:mean yq:point zi:point
     ! variants: {KHTR_v,KHTR_v_xyave}
 "KHTR_h"  [Unused] (CMOR equivalent is "diftrelo")
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Epipycnal tracer diffusivity at tracer cell center
     ! units: m2 s-1
     ! cell_methods: xh:mean yh:mean zi:point area:mean
@@ -2518,19 +2518,19 @@
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
 "u_dyn"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Zonal velocity after the dynamics update
     ! units: m s-1
     ! cell_methods: xq:point yh:mean zl:mean
     ! variants: {u_dyn,u_dyn_xyave}
 "v_dyn"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Meridional velocity after the dynamics update
     ! units: m s-1
     ! cell_methods: xh:mean yq:point zl:mean
     ! variants: {v_dyn,v_dyn_xyave}
 "h_dyn"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Layer Thickness after the dynamics update
     ! units: m
     ! cell_methods: xh:mean yh:mean zl:sum area:mean
@@ -2541,26 +2541,26 @@
     ! units: m
     ! cell_methods: xh:mean yh:mean area:mean
 "uhtr"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Accumulated zonal thickness fluxes to advect tracers
     ! units: m3
     ! cell_methods: xq:point yh:sum zl:sum
     ! variants: {uhtr,uhtr_xyave}
 "vhtr"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Accumulated meridional thickness fluxes to advect tracers
     ! units: m3
     ! cell_methods: xh:sum yq:point zl:sum
     ! variants: {vhtr,vhtr_xyave}
-"umo"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+"umo"  [Used]
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Ocean Mass X Transport
     ! units: kg s-1
     ! standard_name: ocean_mass_x_transport
     ! cell_methods: xq:point yh:sum zl:sum
     ! variants: {umo,umo_xyave}
-"vmo"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+"vmo"  [Used]
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Ocean Mass Y Transport
     ! units: kg s-1
     ! standard_name: ocean_mass_y_transport
@@ -2579,61 +2579,61 @@
     ! standard_name: ocean_mass_y_transport_vertical_sum
     ! cell_methods: xh:sum yq:point
 "dynamics_h"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Layer thicknesses prior to horizontal dynamics
     ! units: m
     ! cell_methods: xh:mean yh:mean zl:sum area:mean
     ! variants: {dynamics_h,dynamics_h_xyave}
 "dynamics_h_tendency"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Change in layer thicknesses due to horizontal dynamics
     ! units: m s-1
     ! cell_methods: xh:mean yh:mean zl:sum area:mean
     ! variants: {dynamics_h_tendency,dynamics_h_tendency_xyave}
 "temp"  [Used] (CMOR equivalent is "thetao")
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Potential Temperature
     ! units: degC
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {temp,temp_xyave,thetao,thetao_xyave}
 "temp_post_horzn"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Potential Temperature after horizontal transport (advection/diffusion) has occurred
     ! units: degC
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {temp_post_horzn,temp_post_horzn_xyave}
 "T_adx"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Advective (by residual mean) Zonal Flux of Heat
     ! units: W
     ! cell_methods: xq:point yh:sum zl:sum
     ! variants: {T_adx,T_adx_xyave}
 "T_ady"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Advective (by residual mean) Meridional Flux of Heat
     ! units: W
     ! cell_methods: xh:sum yq:point zl:sum
     ! variants: {T_ady,T_ady_xyave}
 "T_diffx"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Diffusive Zonal Flux of Heat
     ! units: W
     ! cell_methods: xq:point yh:sum zl:sum
     ! variants: {T_diffx,T_diffx_xyave}
 "T_diffy"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Diffusive Meridional Flux of Heat
     ! units: W
     ! cell_methods: xh:sum yq:point zl:sum
     ! variants: {T_diffy,T_diffy_xyave}
 "T_hbd_diffx"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Horizontal Boundary Diffusive Zonal Flux of Heat
     ! units: W
     ! cell_methods: xq:point yh:sum zl:sum
     ! variants: {T_hbd_diffx,T_hbd_diffx_xyave}
 "T_hbd_diffy"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Horizontal Boundary Diffusive Meridional Flux of Heat
     ! units: W
     ! cell_methods: xh:sum yq:point zl:sum
@@ -2669,7 +2669,7 @@
     ! units: W
     ! cell_methods: xh:sum yq:point
 "T_advection_xy"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Horizontal convergence of residual mean advective fluxes of heat
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean zl:sum area:mean
@@ -2680,13 +2680,13 @@
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
 "T_tendency"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Net time tendency for potential temperature
     ! units: degC s-1
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {T_tendency,T_tendency_xyave}
 "T_dfxy_cont_tendency"  [Unused] (CMOR equivalent is "opottemppmdiff")
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Neutral diffusion tracer content tendency for T
     ! units: W m-2
     ! cell_methods: xh:sum yh:sum zl:sum area:sum
@@ -2698,7 +2698,7 @@
     ! cell_methods: xh:sum yh:sum area:sum
     ! variants: {T_dfxy_cont_tendency_2d,opottemppmdiff_2d}
 "T_hbdxy_cont_tendency"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Horizontal boundary diffusion tracer content tendency for T
     ! units: W m-2
     ! cell_methods: xh:sum yh:sum zl:sum area:sum
@@ -2709,19 +2709,19 @@
     ! units: W m-2
     ! cell_methods: xh:sum yh:sum area:sum
 "T_dfxy_conc_tendency"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Neutral diffusion tracer concentration tendency for T
     ! units: degC s-1
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {T_dfxy_conc_tendency,T_dfxy_conc_tendency_xyave}
 "T_hbdxy_conc_tendency"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Horizontal diffusion tracer concentration tendency for T
     ! units: degC s-1
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {T_hbdxy_conc_tendency,T_hbdxy_conc_tendency_xyave}
 "Th_tendency"  [Unused] (CMOR equivalent is "opottemptend")
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Net time tendency for heat
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean zl:sum area:mean
@@ -2733,13 +2733,13 @@
     ! cell_methods: xh:mean yh:mean area:mean
     ! variants: {Th_tendency_2d,opottemptend_2d}
 "T_tendency_vert_remap"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Vertical remapping tracer concentration tendency for temp
     ! units: degC s-1
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {T_tendency_vert_remap,T_tendency_vert_remap_xyave}
 "Th_tendency_vert_remap"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Vertical remapping tracer content tendency for Heat
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean zl:sum area:mean
@@ -2750,55 +2750,55 @@
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
 "T_vardec"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: ALE variance decay for potential temperature
     ! units: degC2 s-1
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {T_vardec,T_vardec_xyave}
 "salt"  [Used] (CMOR equivalent is "so")
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Salinity
     ! units: psu
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {salt,salt_xyave,so,so_xyave}
 "salt_post_horzn"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Salinity after horizontal transport (advection/diffusion) has occurred
     ! units: psu
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {salt_post_horzn,salt_post_horzn_xyave}
 "S_adx"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Advective (by residual mean) Zonal Flux of Salt
     ! units: psu m3 s-1
     ! cell_methods: xq:point yh:sum zl:sum
     ! variants: {S_adx,S_adx_xyave}
 "S_ady"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Advective (by residual mean) Meridional Flux of Salt
     ! units: psu m3 s-1
     ! cell_methods: xh:sum yq:point zl:sum
     ! variants: {S_ady,S_ady_xyave}
 "S_diffx"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Diffusive Zonal Flux of Salt
     ! units: psu m3 s-1
     ! cell_methods: xq:point yh:sum zl:sum
     ! variants: {S_diffx,S_diffx_xyave}
 "S_diffy"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Diffusive Meridional Flux of Salt
     ! units: psu m3 s-1
     ! cell_methods: xh:sum yq:point zl:sum
     ! variants: {S_diffy,S_diffy_xyave}
 "S_hbd_diffx"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Horizontal Boundary Diffusive Zonal Flux of Salt
     ! units: psu m3 s-1
     ! cell_methods: xq:point yh:sum zl:sum
     ! variants: {S_hbd_diffx,S_hbd_diffx_xyave}
 "S_hbd_diffy"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Horizontal Boundary Diffusive Meridional Flux of Salt
     ! units: psu m3 s-1
     ! cell_methods: xh:sum yq:point zl:sum
@@ -2834,7 +2834,7 @@
     ! units: psu m3 s-1
     ! cell_methods: xh:sum yq:point
 "S_advection_xy"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Horizontal convergence of residual mean advective fluxes of salt
     ! units: kg m-2 s-1
     ! cell_methods: xh:mean yh:mean zl:sum area:mean
@@ -2845,13 +2845,13 @@
     ! units: kg m-2 s-1
     ! cell_methods: xh:mean yh:mean area:mean
 "S_tendency"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Net time tendency for salinity
     ! units: psu s-1
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {S_tendency,S_tendency_xyave}
 "S_dfxy_cont_tendency"  [Unused] (CMOR equivalent is "osaltpmdiff")
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Neutral diffusion tracer content tendency for S
     ! units: kg m-2 s-1
     ! cell_methods: xh:sum yh:sum zl:sum area:sum
@@ -2863,7 +2863,7 @@
     ! cell_methods: xh:sum yh:sum area:sum
     ! variants: {S_dfxy_cont_tendency_2d,osaltpmdiff_2d}
 "S_hbdxy_cont_tendency"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Horizontal boundary diffusion tracer content tendency for S
     ! units: kg m-2 s-1
     ! cell_methods: xh:sum yh:sum zl:sum area:sum
@@ -2874,19 +2874,19 @@
     ! units: kg m-2 s-1
     ! cell_methods: xh:sum yh:sum area:sum
 "S_dfxy_conc_tendency"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Neutral diffusion tracer concentration tendency for S
     ! units: psu s-1
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {S_dfxy_conc_tendency,S_dfxy_conc_tendency_xyave}
 "S_hbdxy_conc_tendency"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Horizontal diffusion tracer concentration tendency for S
     ! units: psu s-1
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {S_hbdxy_conc_tendency,S_hbdxy_conc_tendency_xyave}
 "Sh_tendency"  [Unused] (CMOR equivalent is "osalttend")
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Net time tendency for salt
     ! units: kg m-2 s-1
     ! cell_methods: xh:mean yh:mean zl:sum area:mean
@@ -2898,13 +2898,13 @@
     ! cell_methods: xh:mean yh:mean area:mean
     ! variants: {Sh_tendency_2d,osalttend_2d}
 "S_tendency_vert_remap"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Vertical remapping tracer concentration tendency for salt
     ! units: psu s-1
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {S_tendency_vert_remap,S_tendency_vert_remap_xyave}
 "Sh_tendency_vert_remap"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Vertical remapping tracer content tendency for Salt
     ! units: kg m-2 s-1
     ! cell_methods: xh:mean yh:mean zl:sum area:mean
@@ -2915,55 +2915,55 @@
     ! units: kg m-2 s-1
     ! cell_methods: xh:mean yh:mean area:mean
 "S_vardec"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: ALE variance decay for salinity
     ! units: psu2 s-1
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {S_vardec,S_vardec_xyave}
 "age"  [Used] (CMOR equivalent is "agessc")
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Ideal Age Tracer
     ! units: yr
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {age,age_xyave,agessc,agessc_xyave}
 "age_post_horzn"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Ideal Age Tracer after horizontal transport (advection/diffusion) has occurred
     ! units: yr
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {age_post_horzn,age_post_horzn_xyave}
 "age_adx"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Ideal Age Tracer advective zonal flux
     ! units: yr m3 s-1
     ! cell_methods: xq:point yh:sum zl:sum
     ! variants: {age_adx,age_adx_xyave}
 "age_ady"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Ideal Age Tracer advective meridional flux
     ! units: yr m3 s-1
     ! cell_methods: xh:sum yq:point zl:sum
     ! variants: {age_ady,age_ady_xyave}
 "age_dfx"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Ideal Age Tracer diffusive zonal flux
     ! units: yr m3 s-1
     ! cell_methods: xq:point yh:sum zl:sum
     ! variants: {age_dfx,age_dfx_xyave}
 "age_dfy"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Ideal Age Tracer diffusive meridional flux
     ! units: yr m3 s-1
     ! cell_methods: xh:sum yq:point zl:sum
     ! variants: {age_dfy,age_dfy_xyave}
 "age_hbd_diffx"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Ideal Age Tracer diffusive zonal flux from the horizontal boundary diffusion scheme
     ! units: yr m3 s-1
     ! cell_methods: xq:point yh:sum zl:sum
     ! variants: {age_hbd_diffx,age_hbd_diffx_xyave}
 "age_hbd_diffy"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Ideal Age Tracer diffusive meridional flux from the horizontal boundary diffusion scheme
     ! units: yr m3 s-1
     ! cell_methods: xh:sum yq:point zl:sum
@@ -2999,7 +2999,7 @@
     ! units: yr m3 s-1
     ! cell_methods: xh:sum yq:point
 "age_advection_xy"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Horizontal convergence of residual mean advective fluxes of ideal age tracer
     ! units: yr m s-1
     ! cell_methods: xh:mean yh:mean zl:sum area:mean
@@ -3010,13 +3010,13 @@
     ! units: yr m s-1
     ! cell_methods: xh:mean yh:mean area:mean
 "age_tendency"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Net time tendency for ideal age tracer
     ! units: yr s-1
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {age_tendency,age_tendency_xyave}
 "age_dfxy_cont_tendency"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Neutral diffusion tracer content tendency for age
     ! units: yr m s-1
     ! cell_methods: xh:sum yh:sum zl:sum area:sum
@@ -3027,7 +3027,7 @@
     ! units: yr m s-1
     ! cell_methods: xh:sum yh:sum area:sum
 "age_hbdxy_cont_tendency"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Horizontal boundary diffusion tracer content tendency for age
     ! units: yr m s-1
     ! cell_methods: xh:sum yh:sum zl:sum area:sum
@@ -3038,19 +3038,19 @@
     ! units: yr m s-1
     ! cell_methods: xh:sum yh:sum area:sum
 "age_dfxy_conc_tendency"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Neutral diffusion tracer concentration tendency for age
     ! units: yr s-1
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {age_dfxy_conc_tendency,age_dfxy_conc_tendency_xyave}
 "age_hbdxy_conc_tendency"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Horizontal diffusion tracer concentration tendency for age
     ! units: yr s-1
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {age_hbdxy_conc_tendency,age_hbdxy_conc_tendency_xyave}
 "ageh_tendency"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Net time tendency for ideal age tracer
     ! units: yr m s-1
     ! cell_methods: xh:mean yh:mean zl:sum area:mean
@@ -3061,13 +3061,13 @@
     ! units: yr m s-1
     ! cell_methods: xh:mean yh:mean area:mean
 "age_tendency_vert_remap"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Vertical remapping tracer concentration tendency for age
     ! units: yr s-1
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {age_tendency_vert_remap,age_tendency_vert_remap_xyave}
 "ageh_tendency_vert_remap"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Vertical remapping tracer content tendency for Ideal Age Tracer
     ! units: yr m s-1
     ! cell_methods: xh:mean yh:mean zl:sum area:mean
@@ -3078,61 +3078,61 @@
     ! units: yr m s-1
     ! cell_methods: xh:mean yh:mean area:mean
 "age_vardec"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: ALE variance decay for ideal age tracer
     ! units: yr2 s-1
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {age_vardec,age_vardec_xyave}
 "u_preale"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Zonal velocity before remapping
     ! units: m s-1
     ! cell_methods: xq:point yh:mean zl:mean
     ! variants: {u_preale,u_preale_xyave}
 "v_preale"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Meridional velocity before remapping
     ! units: m s-1
     ! cell_methods: xh:mean yq:point zl:mean
     ! variants: {v_preale,v_preale_xyave}
 "h_preale"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Layer Thickness before remapping
     ! units: m
     ! cell_methods: xh:mean yh:mean zl:sum area:mean
     ! variants: {h_preale,h_preale_xyave}
 "T_preale"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Temperature before remapping
     ! units: degC
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {T_preale,T_preale_xyave}
 "S_preale"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Salinity before remapping
     ! units: PSU
     ! cell_methods: xh:mean yh:mean zl:mean area:mean
     ! variants: {S_preale,S_preale_xyave}
 "e_preale"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Interface Heights before remapping
     ! units: m
     ! cell_methods: xh:mean yh:mean zi:point area:mean
     ! variants: {e_preale,e_preale_xyave}
 "dzRegrid"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Change in interface height due to ALE regridding
     ! units: m
     ! cell_methods: xh:mean yh:mean zi:point area:mean
     ! variants: {dzRegrid,dzRegrid_xyave}
 "vert_remap_h"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: layer thicknesses after ALE regridding and remapping
     ! units: m
     ! cell_methods: xh:mean yh:mean zl:sum area:mean
     ! variants: {vert_remap_h,vert_remap_h_xyave}
 "vert_remap_h_tendency"  [Unused]
-    ! modules: {ocean_model,ocean_model_z,ocean_model_d2,ocean_model_z_d2}
+    ! modules: {ocean_model,ocean_model_z,ocean_model_rho2,ocean_model_d2,ocean_model_z_d2,ocean_model_rho2_d2}
     ! long_name: Layer thicknesses tendency due to ALE regridding and remapping
     ! units: m s-1
     ! cell_methods: xh:mean yh:mean zl:sum area:mean


### PR DESCRIPTION
<!-- use these prompts for changes to configuration branhces, skip them for main branch changes -->
**1. Summary**:

This PR adds vertical remapping of 3D MOM diagnostics to rho and z coords. Discussion of the chosen rho coordinate can be found in #584. The z coordinate is taken from the `ocean_vgrid.nc` input.

Before this change, we were outputting the following 3D diagnostics on the native vertical coordinate:

| variable | description |
| --- | --- |
| `h` | Layer Thickness |
| `agessc` | Sea water age since surface contact |
| `rhopot2` | Potential density referenced to 2000 dbar |
| `thetao` | Potential Temperature |
| `so` | Salinity |
| `uo` | u velocity |
| `vo` | v velocity |
| `uh` | Zonal Thickness Flux |
| `vh` | Meridional Thickness Flux |
| `uhGM` | Time Mean Diffusive Zonal Thickness Flux |
| `vhGM` | Time Mean Diffusive Meridional Thickness Flux |
| `thkcello` | Cell Thickness |
| `KE` | Layer Kinetic energy per unit mass |

With this change, we output the following 3D diagnostics on **z levels**:

| variable | description |
| --- | --- |
| `agessc` | Sea water age since surface contact |
| `rhopot2` | Potential density referenced to 2000 dbar |
| `thetao` | Potential Temperature |
| `so` | Salinity |
| `uo` | u velocity |
| `vo` | v velocity |
| `KE` | Layer Kinetic energy per unit mass |

and the following on **rho2 levels**:

| variable | description |
| --- | --- |
| `e` | Interface height relative to mean sea level |
| `umo` | Ocean Mass X Transport |
| `vmo` | Ocean Mass Y Transport |

No 3D diagnostics are output on native vertical coordinates.

**NOTE**: the changes in this PR have a significant impact on the runtime of the configuration:
- Prior to this PR: **3hr 6min** per model year
- With this PR: **3hr 37min** per model year

Runtime could be reduced by
- regridding to fewer levels (currently 75 for both the z and rho2 coords) and/or 
- reducing the number of 3D variables.

**See [below](https://github.com/ACCESS-NRI/access-om3-configs/pull/622#issuecomment-3031962668) for results of some more testing**

I'd appreciate opinions on whether we should change either before merging (@AndyHoggANU, @aekiss).

**2. Issues Addressed:**
<!-- Add links to github issue(s) this is related to -->
Closes #584

**4. Ad-hoc Testing**

I've run the configuration for a few years. Some output is plotted in #584.

**5. CI Testing**
<!-- Has the CI-testing been run? -->
- [x] `!test repro` has been run

**6. Reproducibility**

Is this reproducible with the previous commit? (If not, why not?)
- [x] Yes
- [ ] No - `!test repro commit` has been run. <!-- add detail below for why it's answer changing --> 

**7. Documentation**
<!--Does this impact documentation? Has the wiki been updated? Have the `docs/MOM_*` files been updated ?-->

The docs folder has been updated with output from running the model?
- [x] Yes
- [ ] N/A

**8. Formatting**
<!-- Are changes to MOM_input in the same order as docs/MOM_parameter_docs.short? -->

Changes to MOM_input have been copied from model output in docs/MOM_parameter_docs.short?
- [x] Yes
- [ ] N/A

**9. Merge Strategy**
<!-- What is the planned merge strategy (Merge commit, Rebase and merge, or squash) ?
If not squash, link to the related issue in the commit descriptions -->

- [ ] Merge commit
- [x] Rebase and merge
- [ ] Squash
