### PR TITLE
Update Edit-Config-Docs.md

### DIFF
--- a/documentation/docs/pages/contributing/Edit-Config-Docs.md
+++ b/documentation/docs/pages/contributing/Edit-Config-Docs.md
@@ -9,7 +9,7 @@ All contributions are welcome but we would particularly appreciate text suggesti
 
 The simplest and fastest way to make a change to an _existing_ page is to click the edit "pencil" on the top-right corner. This will go to the relevant GitHub markdown file and clicking the top-right pencil again on GitHub will allow you to edit the file. Once complete, click `Commit changes...`. There are then _two_ possibilities, depending on whether you have  write access to [`access-om3-configs`](https://github.com/ACCESS-NRI/access-om3-configs): 
 
-1.  **No write access** (e.g. you are not part of the `ACCESS-NRI` GitHub organisation): this will prompt you to make a fork and then a pull request (less than 1 minute!). 
+1.  **No write access**: this will prompt you to make a fork and then a pull request (less than 1 minute!). 
 1.  **You have write access**: please commit changes on a new branch and then use a pull request (this relates to the next option). 
 
 ### Larger contributions (online PR-previews)


### PR DESCRIPTION
Remove section on not having write privileges due not being part of ACCESS-NRI due to github management changes

<!-- use these prompts for changes to configuration branhces, skip them for main branch changes -->
**1. Summary**:

Tiny adjustment in the docs- since we changed the way we manage Github permissions, the statement

**No write access**: (e.g. you are not part of the `ACCESS-NRI` Github organisation)

seems no longer quite accurate. Came across this when using the OM3 docs as a starting point for the AM3 docs. Suggested change is to remove the bracketed part, maybe add a bit on asking for privileges?

**9. Merge Strategy**
<!-- What is the planned merge strategy (Merge commit, Rebase and merge, or squash) ?
If not squash, link to the related issue in the commit descriptions -->

- [x] Merge commit
