### PR TITLE
Test prerelease access-om3/pr166

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -16,9 +16,9 @@ sync:
 #Model software version
 modules:
     use:
-        - /g/data/vk83/modules
+        - /g/data/vk83/prerelease/modules
     load:
-        - access-om3/2025.08.001
+        - access-om3/pr166-3
 
 queue: normal
 ncpus: 240

--- a/manifests/exe.yaml
+++ b/manifests/exe.yaml
@@ -2,7 +2,7 @@ format: yamanifest
 version: 1.0
 ---
 work/access-om3-MOM6-CICE6:
-  fullpath: /g/data/vk83/apps/spack/0.22/release/linux-rocky8-x86_64_v4/oneapi-2025.2.0/access3-2025.08.000-n2qsfzdl7syl4k6m4dx3ydqxarpkmw6l/bin/access-om3-MOM6-CICE6
+  fullpath: /g/data/vk83/prerelease/apps/spack/0.22/release/linux-rocky8-x86_64_v4/oneapi-2025.2.0/access3-2025.08.000-j3bma557vvc5r6pq5zz32gdiho3qlhvm/bin/access-om3-MOM6-CICE6
   hashes:
-    binhash: 2c767b4b07ae2e86e21b4a50582de8df
-    md5: cda3625020745cae76fcfc1f800ef4b3
+    binhash: 8311893b09e69796a16682c4f36b9f26
+    md5: 2144aec3eb8d79ee94173f4a327c1367


### PR DESCRIPTION
PR for testing prereleases from https://github.com/ACCESS-NRI/ACCESS-OM3/pull/166, which includes a MOM6 solo executable as part of the ACCESS-OM3 deployment.