### PR TITLE
Cherry-pick commits from #1011

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -74,7 +74,7 @@ platform:
 collate:
   restart: true
   mpi: true
-  walltime: 3:00:00
+  walltime: 6:00:00
   mem: 30GB
   ncpus: 4
   queue: normalsr


### PR DESCRIPTION
Cherry-picking commit(s) 1734ba9f249dd1bca4c5c48bffbb53c4187d50bc from #1011 into [dev-MC_25km_jra_ryf+wombatlite](https://github.com/ACCESS-NRI/access-om3-configs/tree/dev-MC_25km_jra_ryf+wombatlite).

The extended walltime is 6 hours, not 4 hours as in the other configs, due to the additional WOMBAT diagnostics. This is working reliably for the 25km WOMBATlite experiment underway.