### PR TITLE
Update CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -108,7 +108,7 @@ identifiers:
     value: 10.5281/zenodo.16294824
   - description: "The versioned DOI"
     type: doi
-    value: 10.5281/zenodo.17797678
+    value: 10.5281/zenodo.17971215
 repository-code: 'https://github.com/accESS-NRI/access-om3-configs'
 url: 'https://access-om3-configs.access-hive.org.au/'
 repository-artifact: >-


### PR DESCRIPTION
Fix the DOI used in the 25km IAF release branch

The DOI in https://github.com/ACCESS-NRI/access-om3-configs/tree/release-MC_25km_jra_iaf-1.0-beta will still be wrong - but there is no way to fix that now (except doing a new release)