### PR TITLE
Scheduled repro tests: skip `repro_restart` on MCW 100km

### DIFF
--- a/config/ci.json
+++ b/config/ci.json
@@ -11,7 +11,7 @@
             "markers": "repro or access_om3 or dev_config"
         },
         "dev-MCW_100km_jra_ryf": {
-            "markers": "repro or access_om3 or dev_config"
+            "markers": "repro and (not repro_restart) or access_om3 or dev_config"
         },
          "dev-MC_25km_jra_ryf": {
             "markers": "repro or access_om3 or dev_config"


### PR DESCRIPTION
<!-- use these prompts for changes to configuration branhces, skip them for main branch changes -->
**1. Summary**:

The MCW configs are not restart reproducible due to https://github.com/ACCESS-NRI/access-om3-configs/issues/949

This PR skips checking MCW 100km restart reproducibility as part of the weekly scheduled checks.

**2. Issues Addressed:**
<!-- Add links to github issue(s) this is related to -->
- https://github.com/ACCESS-NRI/access-om3-configs/issues/1036