### PR TITLE
Updating OM3 GM parameters: dev-MC_25km_jra_ryf

### DIFF
--- a/MOM_input
+++ b/MOM_input
@@ -310,13 +310,13 @@ MEKE_GMCOEFF = 1.0              !   [nondim] default = -1.0
                                 ! conversion is not used or calculated.
 MEKE_BGSRC = 1.0E-13            !   [W kg-1] default = 0.0
                                 ! A background energy source for MEKE.
-MEKE_KHTH_FAC = 0.5             !   [nondim] default = 0.0
+MEKE_KHTH_FAC = 0.3             !   [nondim] default = 0.0
                                 ! A factor that maps MEKE%Kh to KhTh.
-MEKE_KHTR_FAC = 0.5             !   [nondim] default = 0.0
+MEKE_KHTR_FAC = 0.3             !   [nondim] default = 0.0
                                 ! A factor that maps MEKE%Kh to KhTr.
 MEKE_KHMEKE_FAC = 1.0           !   [nondim] default = 0.0
                                 ! A factor that maps MEKE%Kh to Kh for MEKE itself.
-MEKE_VISCOSITY_COEFF_KU = 1.0   !   [nondim] default = 0.0
+MEKE_VISCOSITY_COEFF_KU = 0.6   !   [nondim] default = 0.0
                                 ! If non-zero, is the scaling coefficient in the expression forviscosity used to
                                 ! parameterize harmonic lateral momentum mixing byunresolved eddies represented
                                 ! by MEKE. Can be negative torepresent backscatter from the unresolved eddies.


### PR DESCRIPTION
Updating OM3 GM parameters as suggested by @AndyHoggANU: https://github.com/ACCESS-NRI/access-om3-configs/issues/1100#issuecomment-3834385742

**1. Summary**:

What has changed?

```markdown
MEKE_KHTH_FAC = 0.3
MEKE_KHTR_FAC = 0.3
MEKE_VISCOSITY_COEFF_KU = 0.6
```

Why was this done?

Reduce unrealistically large GM parameters.

**2. Issues Addressed:**
Related: https://github.com/ACCESS-NRI/access-om3-configs/issues/1100#issuecomment-3834385742

**3. Dependencies (e.g. on payu, model or om3-scripts)**

This change requires changes to (note required version where true):
- [ ] payu:
- [ ] access-om3:
- [ ] om3-scripts:
<!-- Describe and link to the related changes to dependencies -->

**4. Ad-hoc Testing**

What ad-hoc testing was done? How are you convinced this change is correct (plots are good)?

**5. CI Testing**
<!-- Has the CI-testing been run? -->
- [ ] `!test repro` has been run

**6. Reproducibility**

Is this reproducible with the previous commit? (If not, why not?)
- [ ] Yes
- [ ] No - `!test repro commit` has been run. <!-- add detail below for why it's answer changing --> 

**7. Documentation**
<!--Does this impact documentation? Has the wiki been updated? Have the `docs/MOM_*` files been updated ?-->

The docs folder has been updated with output from running the model?
- [ ] Yes
- [ ] N/A

A PR has been created for updating the documentation?
- [ ] Yes: <!--link-->
- [ ] N/A

**8. Formatting**
<!-- Are changes to MOM_input in the same order as docs/MOM_parameter_docs.short? -->

Changes to MOM_input have been copied from model output in docs/MOM_parameter_docs.short?
- [ ] Yes
- [ ] N/A

**9. Merge Strategy**
<!-- What is the planned merge strategy (Merge commit, Rebase and merge, or squash) ?
If not squash, link to the related issue in the commit descriptions -->

- [ ] Merge commit
- [ ] Rebase and merge
- [ ] Squash
