### PR TITLE
adding a tip and trick on the github cherry-pick workflow

### DIFF
--- a/documentation/docs/pages/Tips-and-tricks.md
+++ b/documentation/docs/pages/Tips-and-tricks.md
@@ -164,9 +164,11 @@ Here are the steps to use the ACCESS Github cherry-pick workflow
 
 1. Open a PR against one config ([example](https://github.com/ACCESS-NRI/access-om3-configs/pull/1101)).
 2. If the change affects answers, update checksums with `!test repro commit`.
-3. Get the PR reviewed and merged.
+3. Update the "docs" folder ([example](https://github.com/ACCESS-NRI/access-om3-configs/tree/dev-MC_25km_jra_iaf/docs)) with the latest version of the MOM docs (i.e. re-run the model and commit those files).
+4. Get the PR reviewed and merged.
 1. Use `!cherry-pick` workflow to cherry-pick changes (except for commit updating checksums) into other configs (see [example](https://github.com/ACCESS-NRI/access-om3-configs/pull/1098) and where it came [from](https://github.com/ACCESS-NRI/access-om3-configs/pull/1092#issuecomment-3815178906)). This will automatically open PRs for you.
 1. Run `!test repro commit` in each of the cherry-picked PRs.
 2. Review and merge.
+
 
 


### PR DESCRIPTION
Related https://github.com/ACCESS-NRI/access-om3-configs/issues/1100. When trying to implement 1100 wasn't totally clear of best way to apply multiple changes.

So this issue is to add a tip and trick on the github cherry-pick workflow

See discussion here: [#ocean-seaice > OM3 25km IAF release: MEKE and GM in MOM6 docs @ 💬](https://access-nri.zulipchat.com/#narrow/channel/470332-ocean-seaice/topic/OM3.2025km.20IAF.20release.3A.20.20MEKE.20and.20GM.20in.20MOM6.20docs/near/571544112)

@dougiesquire [originally wrote this text](https://access-nri.zulipchat.com/#narrow/channel/470332-ocean-seaice/topic/OM3.2025km.20IAF.20release.3A.20.20MEKE.20and.20GM.20in.20MOM6.20docs/near/571545421) and I've slightly tweaked it.

Open to it being moved to the [git practices](https://access-om3-configs.access-hive.org.au/pr-previews/1105/infrastructure/Git-practices/) section too if that's a better fit?