### PR TITLE
Update diagnostics reference from MOM5 to MOM6

### DIFF
--- a/diag_table_source.yaml
+++ b/diag_table_source.yaml
@@ -7,7 +7,7 @@
 # The MOM diag_table format is defined here:
 # https://mom6.readthedocs.io/en/main/api/generated/pages/Diagnostics.html
 # https://www.youtube.com/watch?v=D_J8eg3G80o
-# https://github.com/mom-ocean/MOM5/blob/master/src/shared/diag_manager/diag_table.F90
+# https://github.com/NOAA-GFDL/FMS/blob/main/diag_manager/diag_table.F90
 #######################################################################################################
 
 


### PR DESCRIPTION
Closes https://github.com/ACCESS-NRI/access-om3-configs/issues/1200

I think it would be more intuitive if this header was updated to reflect om3 given it's in access-om3-configs.

I suppose this affects quite a few of our configs?