### PR TITLE
om3 config docs: config list out of date

### DIFF
--- a/documentation/docs/index.md
+++ b/documentation/docs/index.md
@@ -134,5 +134,5 @@ The following links can be used to easily compare different configuration branch
 
 **JRA55do ← ERA5**
 
-- [`dev-MC_100km_jra_iaf`⬅️`MC_100km_era_iaf`](https://github.com/ACCESS-NRI/access-om3-configs/compare/dev-MC_100km_jra_ryf...MC_100km_era_iaf)
+- [`dev-MC_100km_jra_iaf`⬅️`MC_100km_era_iaf`](https://github.com/ACCESS-NRI/access-om3-configs/compare/dev-MC_100km_jra_iaf...MC_100km_era_iaf)
 

--- a/documentation/docs/index.md
+++ b/documentation/docs/index.md
@@ -79,6 +79,7 @@ Currently the following development configurations are available:
 
 - [`dev-MC_100km_jra_ryf`](https://github.com/ACCESS-NRI/access-om3-configs/tree/dev-MC_100km_jra_ryf);
 - [`dev-MC_100km_jra_iaf`](https://github.com/ACCESS-NRI/access-om3-configs/tree/dev-MC_100km_jra_iaf);
+- [`MC_100km_era_iaf`](https://github.com/ACCESS-NRI/access-om3-configs/tree/MC_100km_era_iaf);
 - [`dev-MC_100km_jra_ryf+wombatlite`](https://github.com/ACCESS-NRI/access-om3-configs/tree/dev-MC_100km_jra_ryf+wombatlite);
 - [`dev-MC_100km_jra_iaf+wombatlite`](https://github.com/ACCESS-NRI/access-om3-configs/tree/dev-MC_100km_jra_iaf+wombatlite);
 
@@ -101,7 +102,8 @@ Regional configurations:
 **MOM6-CICE6-WW3-DATM-DROF configurations**
 
 - [`dev-MCW_100km_jra_ryf`](https://github.com/ACCESS-NRI/access-om3-configs/tree/dev-MCW_100km_jra_ryf);
-- [`dev-MCW_100km_jra_iaf`](https://github.com/ACCESS-NRI/access-om3-configs/tree/dev-MCW_100km_jra_iaf).
+- [`dev-MCW_100km_jra_iaf`](https://github.com/ACCESS-NRI/access-om3-configs/tree/dev-MCW_100km_jra_iaf);
+- [`MCW_100km_era5_iaf_KPP`](https://github.com/ACCESS-NRI/access-om3-configs/tree/MCW_100km_era5_iaf_KPP).
 
 !!! warning
     These `dev_*` configurations are still under development and should **not** be used for production runs.
@@ -129,4 +131,7 @@ The following links can be used to easily compare different configuration branch
 
 - [`dev-MC_100km_jra_ryf`⬅️`dev-MCW_100km_jra_ryf`](https://github.com/ACCESS-NRI/access-om3-configs/compare/dev-MC_100km_jra_ryf..dev-MCW_100km_jra_ryf)
 - [`dev-MC_100km_jra_iaf`⬅️`dev-MCW_100km_jra_iaf`](https://github.com/ACCESS-NRI/access-om3-configs/compare/dev-MC_100km_jra_iaf..dev-MCW_100km_jra_iaf)
+
+**JRA55do ← ERA5**
+- [`dev-MC_100km_jra_iaf`⬅️`MC_100km_era_iaf`](https://github.com/ACCESS-NRI/access-om3-configs/compare/dev-MC_100km_jra_ryf...MC_100km_era_iaf)
 

--- a/documentation/docs/index.md
+++ b/documentation/docs/index.md
@@ -79,7 +79,6 @@ Currently the following development configurations are available:
 
 - [`dev-MC_100km_jra_ryf`](https://github.com/ACCESS-NRI/access-om3-configs/tree/dev-MC_100km_jra_ryf);
 - [`dev-MC_100km_jra_iaf`](https://github.com/ACCESS-NRI/access-om3-configs/tree/dev-MC_100km_jra_iaf);
-- [`MC_100km_era_iaf`](https://github.com/ACCESS-NRI/access-om3-configs/tree/MC_100km_era_iaf);
 - [`dev-MC_100km_jra_ryf+wombatlite`](https://github.com/ACCESS-NRI/access-om3-configs/tree/dev-MC_100km_jra_ryf+wombatlite);
 - [`dev-MC_100km_jra_iaf+wombatlite`](https://github.com/ACCESS-NRI/access-om3-configs/tree/dev-MC_100km_jra_iaf+wombatlite);
 
@@ -97,13 +96,11 @@ Regional configurations:
 **MOM6-CICE6-DATM-DROF regional configurations**
 
  - [`dev-MC_4km_jra_ryf+regionalpanan`](https://github.com/ACCESS-NRI/access-om3-configs/tree/dev-MC_4km_jra_ryf%2Bregionalpanan)
- - [`dev-MC_4km_jra_ryf+regionalpanan+isf`](https://github.com/ACCESS-NRI/access-om3-configs/tree/dev-MC_4km_jra_ryf%2Bregionalpanan%2Bisf)
 
 **MOM6-CICE6-WW3-DATM-DROF configurations**
 
 - [`dev-MCW_100km_jra_ryf`](https://github.com/ACCESS-NRI/access-om3-configs/tree/dev-MCW_100km_jra_ryf);
-- [`dev-MCW_100km_jra_iaf`](https://github.com/ACCESS-NRI/access-om3-configs/tree/dev-MCW_100km_jra_iaf);
-- [`MCW_100km_era5_iaf_KPP`](https://github.com/ACCESS-NRI/access-om3-configs/tree/MCW_100km_era5_iaf_KPP).
+- [`dev-MCW_100km_jra_iaf`](https://github.com/ACCESS-NRI/access-om3-configs/tree/dev-MCW_100km_jra_iaf).
 
 !!! warning
     These configurations are still under development and should **not** be used for production runs.

--- a/documentation/docs/index.md
+++ b/documentation/docs/index.md
@@ -74,17 +74,31 @@ Currently the following development configurations are available:
 
 **MOM6-CICE6-DATM-DROF configurations**
 
-- [`dev-MC_100km_jra_ryf`](https://github.com/ACCESS-NRI/access-om3-configs/tree/dev-MC_100km_jra_ryf)
-- [`dev-MC_100km_jra_iaf`](https://github.com/ACCESS-NRI/access-om3-configs/tree/dev-MC_100km_jra_iaf)
-- [`dev-MC_100km_jra_ryf+wombatlite`](https://github.com/ACCESS-NRI/access-om3-configs/tree/dev-MC_100km_jra_ryf+wombatlite)
-- [`dev-MC_25km_jra_ryf`](https://github.com/ACCESS-NRI/access-om3-configs/tree/dev-MC_25km_jra_ryf)
-- [`dev-MC_25km_jra_iaf`](https://github.com/ACCESS-NRI/access-om3-configs/tree/dev-MC_25km_jra_iaf)
-- [`dev-MC_25km_jra_ryf+wombatlite`](https://github.com/ACCESS-NRI/access-om3-configs/tree/dev-MC_25km_jra_ryf+wombatlite)
+
+100km configurations: 
+
+- [`dev-MC_100km_jra_ryf`](https://github.com/ACCESS-NRI/access-om3-configs/tree/dev-MC_100km_jra_ryf);
+- [`dev-MC_100km_jra_iaf`](https://github.com/ACCESS-NRI/access-om3-configs/tree/dev-MC_100km_jra_iaf);
+- [`dev-MC_100km_jra_ryf+wombatlite`](https://github.com/ACCESS-NRI/access-om3-configs/tree/dev-MC_100km_jra_ryf+wombatlite);
+- [`dev-MC_100km_jra_iaf+wombatlite`](https://github.com/ACCESS-NRI/access-om3-configs/tree/dev-MC_100km_jra_iaf+wombatlite);
+
+
+25km configurations: 
+
+- [`dev-MC_25km_jra_ryf`](https://github.com/ACCESS-NRI/access-om3-configs/tree/dev-MC_25km_jra_ryf);
+- [`dev-MC_25km_jra_iaf`](https://github.com/ACCESS-NRI/access-om3-configs/tree/dev-MC_25km_jra_iaf);
+- [`dev-MC_25km_jra_ryf+wombatlite`](https://github.com/ACCESS-NRI/access-om3-configs/tree/dev-MC_25km_jra_ryf+wombatlite);
+- [`dev-MC_25km_jra_iaf+wombatlite`](https://github.com/ACCESS-NRI/access-om3-configs/tree/dev-MC_25km_jra_iaf+wombatlite)
+
+**MOM6-CICE6-DATM-DROF regional configurations**
+
+ - [`dev-MC_4km_jra_ryf+regionalpanan`](https://github.com/ACCESS-NRI/access-om3-configs/tree/dev-MC_4km_jra_ryf%2Bregionalpanan)
+ - [`dev-MC_4km_jra_ryf+regionalpanan+isf`](https://github.com/ACCESS-NRI/access-om3-configs/tree/dev-MC_4km_jra_ryf%2Bregionalpanan%2Bisf)
 
 **MOM6-CICE6-WW3-DATM-DROF configurations**
 
-- [`dev-MCW_100km_jra_ryf`](https://github.com/ACCESS-NRI/access-om3-configs/tree/dev-MCW_100km_jra_ryf)
-- [`dev-MCW_100km_jra_iaf`](https://github.com/ACCESS-NRI/access-om3-configs/tree/dev-MCW_100km_jra_iaf)
+- [`dev-MCW_100km_jra_ryf`](https://github.com/ACCESS-NRI/access-om3-configs/tree/dev-MCW_100km_jra_ryf);
+- [`dev-MCW_100km_jra_iaf`](https://github.com/ACCESS-NRI/access-om3-configs/tree/dev-MCW_100km_jra_iaf).
 
 !!! warning
     These `dev_*` configurations are still under development and should **not** be used for production runs.

--- a/documentation/docs/index.md
+++ b/documentation/docs/index.md
@@ -106,7 +106,7 @@ Regional configurations:
 - [`MCW_100km_era5_iaf_KPP`](https://github.com/ACCESS-NRI/access-om3-configs/tree/MCW_100km_era5_iaf_KPP).
 
 !!! warning
-    These `dev_*` configurations are still under development and should **not** be used for production runs.
+    These configurations are still under development and should **not** be used for production runs.
 
 ### Comparison table
 The following links can be used to easily compare different configuration branches
@@ -133,5 +133,6 @@ The following links can be used to easily compare different configuration branch
 - [`dev-MC_100km_jra_iaf`⬅️`dev-MCW_100km_jra_iaf`](https://github.com/ACCESS-NRI/access-om3-configs/compare/dev-MC_100km_jra_iaf..dev-MCW_100km_jra_iaf)
 
 **JRA55do ← ERA5**
+
 - [`dev-MC_100km_jra_iaf`⬅️`MC_100km_era_iaf`](https://github.com/ACCESS-NRI/access-om3-configs/compare/dev-MC_100km_jra_ryf...MC_100km_era_iaf)
 

--- a/documentation/docs/index.md
+++ b/documentation/docs/index.md
@@ -124,7 +124,3 @@ The following links can be used to easily compare different configuration branch
 - [`dev-MC_100km_jra_ryf`⬅️`dev-MCW_100km_jra_ryf`](https://github.com/ACCESS-NRI/access-om3-configs/compare/dev-MC_100km_jra_ryf..dev-MCW_100km_jra_ryf)
 - [`dev-MC_100km_jra_iaf`⬅️`dev-MCW_100km_jra_iaf`](https://github.com/ACCESS-NRI/access-om3-configs/compare/dev-MC_100km_jra_iaf..dev-MCW_100km_jra_iaf)
 
-**JRA55do ← ERA5**
-
-- [`dev-MC_100km_jra_iaf`⬅️`MC_100km_era_iaf`](https://github.com/ACCESS-NRI/access-om3-configs/compare/dev-MC_100km_jra_iaf...MC_100km_era_iaf)
-

--- a/documentation/docs/index.md
+++ b/documentation/docs/index.md
@@ -82,13 +82,16 @@ Currently the following development configurations are available:
 - [`dev-MC_100km_jra_ryf+wombatlite`](https://github.com/ACCESS-NRI/access-om3-configs/tree/dev-MC_100km_jra_ryf+wombatlite);
 - [`dev-MC_100km_jra_iaf+wombatlite`](https://github.com/ACCESS-NRI/access-om3-configs/tree/dev-MC_100km_jra_iaf+wombatlite);
 
-
 25km configurations: 
 
 - [`dev-MC_25km_jra_ryf`](https://github.com/ACCESS-NRI/access-om3-configs/tree/dev-MC_25km_jra_ryf);
 - [`dev-MC_25km_jra_iaf`](https://github.com/ACCESS-NRI/access-om3-configs/tree/dev-MC_25km_jra_iaf);
 - [`dev-MC_25km_jra_ryf+wombatlite`](https://github.com/ACCESS-NRI/access-om3-configs/tree/dev-MC_25km_jra_ryf+wombatlite);
 - [`dev-MC_25km_jra_iaf+wombatlite`](https://github.com/ACCESS-NRI/access-om3-configs/tree/dev-MC_25km_jra_iaf+wombatlite)
+
+Regional configurations:
+
+ - [`dev-MC_4km_jra_ryf+regionalpanan+isf`](https://github.com/ACCESS-NRI/access-om3-configs/tree/dev-MC_4km_jra_ryf%2Bregionalpanan%2Bisf)
 
 **MOM6-CICE6-DATM-DROF regional configurations**
 

--- a/documentation/docs/index.md
+++ b/documentation/docs/index.md
@@ -89,7 +89,7 @@ Currently the following development configurations are available:
 - [`dev-MC_25km_jra_ryf`](https://github.com/ACCESS-NRI/access-om3-configs/tree/dev-MC_25km_jra_ryf);
 - [`dev-MC_25km_jra_iaf`](https://github.com/ACCESS-NRI/access-om3-configs/tree/dev-MC_25km_jra_iaf);
 - [`dev-MC_25km_jra_ryf+wombatlite`](https://github.com/ACCESS-NRI/access-om3-configs/tree/dev-MC_25km_jra_ryf+wombatlite);
-- [`dev-MC_25km_jra_iaf+wombatlite`](https://github.com/ACCESS-NRI/access-om3-configs/tree/dev-MC_25km_jra_iaf+wombatlite)
+- [`dev-MC_25km_jra_iaf+wombatlite`](https://github.com/ACCESS-NRI/access-om3-configs/tree/dev-MC_25km_jra_iaf+wombatlite).
 
 Regional configurations:
 

--- a/documentation/docs/index.md
+++ b/documentation/docs/index.md
@@ -72,8 +72,10 @@ Currently the following released configurations are available:
 
 Currently the following development configurations are available:
 
-**MOM6-CICE6-DATM-DROF configurations**
+!!! warning
+    These `dev-*` configurations are still under development and should **not** be used for production runs.
 
+**MOM6-CICE6-DATM-DROF configurations**
 
 100km configurations: 
 
@@ -101,9 +103,6 @@ Regional configurations:
 
 - [`dev-MCW_100km_jra_ryf`](https://github.com/ACCESS-NRI/access-om3-configs/tree/dev-MCW_100km_jra_ryf);
 - [`dev-MCW_100km_jra_iaf`](https://github.com/ACCESS-NRI/access-om3-configs/tree/dev-MCW_100km_jra_iaf).
-
-!!! warning
-    These configurations are still under development and should **not** be used for production runs.
 
 ### Comparison table
 The following links can be used to easily compare different configuration branches

--- a/documentation/docs/index.md
+++ b/documentation/docs/index.md
@@ -93,10 +93,6 @@ Currently the following development configurations are available:
 
 Regional configurations:
 
- - [`dev-MC_4km_jra_ryf+regionalpanan+isf`](https://github.com/ACCESS-NRI/access-om3-configs/tree/dev-MC_4km_jra_ryf%2Bregionalpanan%2Bisf)
-
-**MOM6-CICE6-DATM-DROF regional configurations**
-
  - [`dev-MC_4km_jra_ryf+regionalpanan`](https://github.com/ACCESS-NRI/access-om3-configs/tree/dev-MC_4km_jra_ryf%2Bregionalpanan)
 
 **MOM6-CICE6-WW3-DATM-DROF configurations**

--- a/documentation/docs/index.md
+++ b/documentation/docs/index.md
@@ -94,8 +94,7 @@ Currently the following development configurations are available:
 Regional configurations:
 
  - [`dev-MC_panan4km_jra_ryf`](https://github.com/ACCESS-NRI/access-om3-configs/tree/dev-MC_panan4km_jra_ryf)
- - [`dev-MC_panan4km_jra_ryf+isf`](https://github.com/ACCESS-NRI/access-om3-configs/tree/dev-MC_panan4km_jra_ryf%2Bisf)
- - 
+ 
 **MOM6-CICE6-WW3-DATM-DROF configurations**
 
 - [`dev-MCW_100km_jra_ryf`](https://github.com/ACCESS-NRI/access-om3-configs/tree/dev-MCW_100km_jra_ryf);

--- a/documentation/docs/index.md
+++ b/documentation/docs/index.md
@@ -93,7 +93,7 @@ Currently the following development configurations are available:
 
 Regional configurations:
 
- - [`dev-MC_panan4km_jra_ryf`](https://github.com/ACCESS-NRI/access-om3-configs/tree/dev-MC_panan4km_jra_ryf)
+ - [`dev-MC_panan4km_jra_ryf`](https://github.com/ACCESS-NRI/access-om3-configs/tree/dev-MC_panan4km_jra_ryf).
  
 **MOM6-CICE6-WW3-DATM-DROF configurations**
 

--- a/documentation/docs/index.md
+++ b/documentation/docs/index.md
@@ -56,7 +56,7 @@ and the nominal resolution is given in kilometers, corresponding to the nominal 
 - `10km`: 0.1°
 - `8km`: 1/12°
 
-For regional configurations, a short word describing the location of the domain is included after the nominal resolution. For example:
+For regional configurations, a short word describing the location of the domain is included before the nominal resolution. For example:
 
 - `tas5km`:    5km resolution around Tasmainia
 - `superoz4km` 4km resolution around Australia

--- a/documentation/docs/index.md
+++ b/documentation/docs/index.md
@@ -93,8 +93,9 @@ Currently the following development configurations are available:
 
 Regional configurations:
 
- - [`dev-MC_4km_jra_ryf+regionalpanan`](https://github.com/ACCESS-NRI/access-om3-configs/tree/dev-MC_4km_jra_ryf%2Bregionalpanan)
-
+ - [`dev-MC_panan4km_jra_ryf`](https://github.com/ACCESS-NRI/access-om3-configs/tree/dev-MC_panan4km_jra_ryf)
+ - [`dev-MC_panan4km_jra_ryf+isf`](https://github.com/ACCESS-NRI/access-om3-configs/tree/dev-MC_panan4km_jra_ryf%2Bisf)
+ - 
 **MOM6-CICE6-WW3-DATM-DROF configurations**
 
 - [`dev-MCW_100km_jra_ryf`](https://github.com/ACCESS-NRI/access-om3-configs/tree/dev-MCW_100km_jra_ryf);

--- a/documentation/docs/index.md
+++ b/documentation/docs/index.md
@@ -47,7 +47,6 @@ where `{MODEL_COMPONENTS}` is an acronym specifying the active model components 
 - `M`: MOM6
 - `C`: CICE6
 - `W`: WW3
-- `r` : a regional configuration
   
 and the nominal resolution is given in kilometers, corresponding to the nominal resolution in degrees as follows:
 


### PR DESCRIPTION
Closes #1202 

--

Config list slightly out of date here:
https://github.com/ACCESS-NRI/access-om3-configs/blob/main/documentation/docs/index.md

(noticed whilst doing https://github.com/ACCESS-NRI/access-om3-configs/pull/1201#issuecomment-4064194778)