### PR TITLE
Updated version of RYF forcing with FillValue set per #1095

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -46,7 +46,7 @@ input:
     - /g/data/vk83/prerelease/configurations/inputs/access-om3/share/meshes/share/2026.01.21/JRA55do-datm-ESMFmesh.nc
     - /g/data/vk83/prerelease/configurations/inputs/access-om3/share/meshes/share/2026.01.21/JRA55do-drof-ESMFmesh.nc
     - /g/data/vk83/prerelease/configurations/inputs/access-om3/cmeps/remap_weights/global.25km/2026.03.17/access-om3-25km-rof-remap-weights.nc
-    - /g/data/vk83/configurations/inputs/JRA-55/RYF/v1-6/data
+    - /g/data/vk83/prerelease/configurations/inputs/JRA-55/RYF/v1-6/2026.04.15
     - /g/data/vk83/prerelease/configurations/inputs/access-om3/share/grids/global.25km/2026.02.25/mask_table.1027.72x48
 
 runlog: true

--- a/manifests/input.yaml
+++ b/manifests/input.yaml
@@ -12,60 +12,60 @@ work/INPUT/JRA55do-drof-ESMFmesh.nc:
     binhash: 9f3ee3ce42e776fcbee8026e0c3880f5
     md5: bf62c4e7786ddfbe56d61b3074d5d16d
 work/INPUT/RYF.friver.1990_1991.nc:
-  fullpath: /g/data/vk83/configurations/inputs/JRA-55/RYF/v1-6/data/RYF.friver.1990_1991.nc
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/JRA-55/RYF/v1-6/2026.04.15/RYF.friver.1990_1991.nc
   hashes:
-    binhash: 7ed1b4267c202eae4e1e1fb7170adfdc
-    md5: 06d549192558fc48c43416b1015044bc
+    binhash: eb2c39ab9384638e11ea50c7f809e8f0
+    md5: beb16730c02db9a730f69dfdc843b774
 work/INPUT/RYF.huss.1990_1991.nc:
-  fullpath: /g/data/vk83/configurations/inputs/JRA-55/RYF/v1-6/data/RYF.huss.1990_1991.nc
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/JRA-55/RYF/v1-6/2026.04.15/RYF.huss.1990_1991.nc
   hashes:
-    binhash: be1a71017ed8b5392505b2b013e05343
-    md5: 76bce15820d66e4dbd55674072253869
+    binhash: ea3f553f869d4654691085f1d99986e3
+    md5: 1b184b232a31382443e5818bb623a9cb
 work/INPUT/RYF.licalvf.1990_1991.nc:
-  fullpath: /g/data/vk83/configurations/inputs/JRA-55/RYF/v1-6/data/RYF.licalvf.1990_1991.nc
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/JRA-55/RYF/v1-6/2026.04.15/RYF.licalvf.1990_1991.nc
   hashes:
-    binhash: e7eb183d2b7cdd685bdee810004cf3c9
-    md5: 33aba38d6bffb45f9b1ce6240c2cd21a
+    binhash: eefaf66dfc5524f47e0906d51964df0d
+    md5: 1d9233a590fb94d052196cdd5245a585
 work/INPUT/RYF.prra.1990_1991.nc:
-  fullpath: /g/data/vk83/configurations/inputs/JRA-55/RYF/v1-6/data/RYF.prra.1990_1991.nc
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/JRA-55/RYF/v1-6/2026.04.15/RYF.prra.1990_1991.nc
   hashes:
-    binhash: 1d8af8b1b94d1cf78a3108477d329d06
-    md5: 4e1210fa78c124c1537e8ce28584555c
+    binhash: 94d00a3d55795feb6ecd8012773430af
+    md5: a03d5b51f44fb9fcad5036a0b7d408d0
 work/INPUT/RYF.prsn.1990_1991.nc:
-  fullpath: /g/data/vk83/configurations/inputs/JRA-55/RYF/v1-6/data/RYF.prsn.1990_1991.nc
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/JRA-55/RYF/v1-6/2026.04.15/RYF.prsn.1990_1991.nc
   hashes:
-    binhash: 5b9d401daa0c90298d703a3a2dac12b1
-    md5: 1fa60bceab287d4059c6a23d5fb18170
+    binhash: 6c6b6395026404e39e67a7211753e875
+    md5: 914dcf6080c0fc9b9d46bf7082a4c0be
 work/INPUT/RYF.psl.1990_1991.nc:
-  fullpath: /g/data/vk83/configurations/inputs/JRA-55/RYF/v1-6/data/RYF.psl.1990_1991.nc
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/JRA-55/RYF/v1-6/2026.04.15/RYF.psl.1990_1991.nc
   hashes:
-    binhash: e85798bf489561d1eb316a50b170f318
-    md5: 40003042b732f70edaf59f302427b213
+    binhash: e3bdf90e84b1e8e75bebbc83a4bd698a
+    md5: 98206e380baf0f229b2983f569f9b0e0
 work/INPUT/RYF.rlds.1990_1991.nc:
-  fullpath: /g/data/vk83/configurations/inputs/JRA-55/RYF/v1-6/data/RYF.rlds.1990_1991.nc
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/JRA-55/RYF/v1-6/2026.04.15/RYF.rlds.1990_1991.nc
   hashes:
-    binhash: 33502887b018dbb288775102c1411d65
-    md5: 449ca4bd2d51794204a6ceedc79bad82
+    binhash: 7a036494befa912be20ff81830cf5f8f
+    md5: 6e9242d3a02c1ee768337dcab710de39
 work/INPUT/RYF.rsds.1990_1991.nc:
-  fullpath: /g/data/vk83/configurations/inputs/JRA-55/RYF/v1-6/data/RYF.rsds.1990_1991.nc
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/JRA-55/RYF/v1-6/2026.04.15/RYF.rsds.1990_1991.nc
   hashes:
-    binhash: ca831af4d8931736138d04166910b7c4
-    md5: 7d8e5270940eaaf5121b72eea736b2cd
+    binhash: 6c148adc1bee28c556b767a12c9538ad
+    md5: 5f9721311ff7ac4908ca79a9d9cfa5fd
 work/INPUT/RYF.tas.1990_1991.nc:
-  fullpath: /g/data/vk83/configurations/inputs/JRA-55/RYF/v1-6/data/RYF.tas.1990_1991.nc
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/JRA-55/RYF/v1-6/2026.04.15/RYF.tas.1990_1991.nc
   hashes:
-    binhash: ae172b9c06fe1b5b2b0a2b78e7de0d17
-    md5: 1947327fb37d4d1e7eee3e1804500721
+    binhash: 6711ed881a4f0973794d1adbec4c80f3
+    md5: 5fdf6d3b0369f1b50138013101c288a6
 work/INPUT/RYF.uas.1990_1991.nc:
-  fullpath: /g/data/vk83/configurations/inputs/JRA-55/RYF/v1-6/data/RYF.uas.1990_1991.nc
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/JRA-55/RYF/v1-6/2026.04.15/RYF.uas.1990_1991.nc
   hashes:
-    binhash: 7271b6b617e233932c5e319a63c64bc3
-    md5: 74516d793e148d522b2b2f73eb6eb6c7
+    binhash: 9fe296a0b9aab65aa6a39d9205357454
+    md5: 264a82753021ba094b54cc0cfae4f3ec
 work/INPUT/RYF.vas.1990_1991.nc:
-  fullpath: /g/data/vk83/configurations/inputs/JRA-55/RYF/v1-6/data/RYF.vas.1990_1991.nc
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/JRA-55/RYF/v1-6/2026.04.15/RYF.vas.1990_1991.nc
   hashes:
-    binhash: f353a71a014062723ed2b56353932caf
-    md5: 30b92b1e409cff9a9900692aa961aba4
+    binhash: 32c97e6ab7f375008a45dbd3dae259f8
+    md5: bd0ccd8ef7f639ca77b6705f0d6d1fcb
 work/INPUT/access-om3-25km-ESMFmesh.nc:
   fullpath: /g/data/vk83/prerelease/configurations/inputs/access-om3/share/meshes/global.25km/2026.03.16/access-om3-25km-ESMFmesh.nc
   hashes:


### PR DESCRIPTION
<!-- use these prompts for changes to configuration branhces, skip them for main branch changes -->
**1. Summary**:

What has changed?

The RYF forcing file was updated so that the FillValue attribute is set

Why was this done?

Avoid NANs

**2. Issues Addressed:**
<!-- Add links to github issue(s) this is related to -->
- #1095 

**3. Dependencies (e.g. on payu, model or om3-scripts)**

This change requires changes to (note required version where true):
- [ ] payu:
- [ ] access-om3:
- [x] om3-scripts: https://github.com/ACCESS-NRI/om3-scripts/commit/eb575de059e9a39dc505a2e42f82420499b8ff7f
<!-- Describe and link to the related changes to dependencies -->

**4. Ad-hoc Testing**

None - CI only


**5. CI Testing**
<!-- Has the CI-testing been run? -->
- [x] `!test repro` or `!test repro commit ` has been run

**6. Reproducibility**

Is this reproducible with the previous commit? (If not, why not?)
- [x] Yes
- [ ] No

**7. Documentation**
<!--Does this impact documentation? Has the wiki been updated? Have the `docs/MOM_*` files been updated ?-->

The docs folder has been updated with output from running the model?
- [ ] Yes
- [x] N/A

A PR has been created for updating the documentation?
- [ ] Yes: <!--link-->
- [x] N/A

**8. Formatting**
<!-- Are changes to MOM_input in the same order as docs/MOM_parameter_docs.short? -->

Changes to MOM_input have been copied from model output in docs/MOM_parameter_docs.short?
- [ ] Yes
- [x] N/A

**9. Merge Strategy**
<!-- What is the planned merge strategy (Merge commit, Rebase and merge, or squash) ?
If not squash, link to the related issue in the commit descriptions -->

- [ ] Merge commit
- [ ] Rebase and merge
- [x] Squash
