### PR TITLE
Cherry pick from pr1302 into dev mc 4km jra ryf+regionalpanan

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -62,10 +62,6 @@ platform:
     nodesize: 104
     nodemem: 512
 
-mpi:
-  flags:
-    - --mca pml ucx --mca coll ^ucc -x UCX_RNDV_THRESH=inf
-
 collate:
   restart: true
   mpi: true
@@ -77,7 +73,7 @@ collate:
 
 mpi:
   flags:
-  - --mca mpi_yield_when_idle true
+  - --mca pml ucx --mca coll ^ucc -x UCX_RNDV_THRESH=inf --mca mpi_yield_when_idle true
 
 userscripts:
     archive: /usr/bin/bash /g/data/vk83/apps/om3-scripts/payu_config/archive.sh

--- a/config.yaml
+++ b/config.yaml
@@ -75,6 +75,10 @@ collate:
   queue: normalsr
   exe: mppnccombine-fast
 
+mpi:
+  flags:
+  - --mca mpi_yield_when_idle true
+
 userscripts:
     archive: /usr/bin/bash /g/data/vk83/apps/om3-scripts/payu_config/archive.sh
 


### PR DESCRIPTION
This sets the MPI argument `mpi_yield_when_idle` per #1245


This was tested as part of #1288 although setting the MOM parameter NONBLOCKING_UPDATES was found to be not reproducible over restarts (see #1312). So we only set the MPI argument here.

