### PR TITLE
Set payu_minimum_version for #1291

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -69,4 +69,4 @@ postscript: -v PROJECT,SCRIPTS_DIR=/g/data/vk83/apps/om3-scripts -lstorage=${PBS
 qsub_flags: -W umask=027
 
 restart_freq: 1YS
-payu_minimum_version: 1.2.0
+payu_minimum_version: 1.3.0


### PR DESCRIPTION
Correction for #1291 


the `base_path` in config `sync` was first available in payu version 1.3.0