### PR TITLE
Note about docs tags when doing config releases

### DIFF
--- a/documentation/docs/pages/infrastructure/Releases.md
+++ b/documentation/docs/pages/infrastructure/Releases.md
@@ -34,7 +34,7 @@ When undertaking releases, the following actions are needed to implement the ite
 - After the release, navigate to the page for the new DOI and upload the tarball from the github release and fill in any details before publishing the DOI.
 
 - Create a tag on the main branch to represent the current state of the config documentation. Tags should used the prefix `docs-` and follow CALVER. For example, if a config is released in August 2025, create a tag from the main branch with the name `docs-2025.08.000` [^3].
-[^3]:To correct documentation related to a prior release, use patch versions, i.e. `docs-2025.08.000.1`)
+[^3]:To correct documentation related to a prior release, use patch versions, e.g. `docs-2025.08.000.1`
 
 ## Control Experiments
 

--- a/documentation/docs/pages/infrastructure/Releases.md
+++ b/documentation/docs/pages/infrastructure/Releases.md
@@ -33,6 +33,9 @@ When undertaking releases, the following actions are needed to implement the ite
 
 - After the release, navigate to the page for the new DOI and upload the tarball from the github release and fill in any details before publishing the DOI.
 
+- Create a tag on the main branch to represent the current state of the config documentation. Tags should used the prefix `docs-` and follow CALVER. For example, if a config is released in August 2025, create a tag from the main branch with the name `docs-2025.08.000` [^3].
+[^3]:To correct documentation related to a prior release, use patch versions, i.e. `docs-2025.08.000.1`)
+
 ## Control Experiments
 
 If sharing data from a control experiment, typically run the control experiment as the last action before merging `dev-` into `release-`. i.e:


### PR DESCRIPTION
https://access-om3-configs.access-hive.org.au/ now uses read the docs 

This adds a note about using read the docs versions (per #752 )