### PR TITLE
Updating Angus' 8km ryf configuration to use the latest `dev-MC_25km_jra_ryf`

### DIFF
--- a/MOM_input
+++ b/MOM_input
@@ -53,11 +53,6 @@ THERMO_SPANS_COUPLING = True    !   [Boolean] default = False
                                 ! coupling timestep. The actual thermodynamic timestep that is used in this case
                                 ! is the largest integer multiple of the coupling timestep that is less than or
                                 ! equal to DT_THERM.
-THICKNESSDIFFUSE = True         !   [Boolean] default = False
-                                ! If true, isopycnal surfaces are diffused with a Laplacian coefficient of KHTH.
-THICKNESSDIFFUSE_FIRST = True   !   [Boolean] default = False
-                                ! If true, do thickness diffusion or interface height smoothing before dynamics.
-                                ! This is only used if THICKNESSDIFFUSE or APPLY_INTERFACE_FILTER is true.
 HFREEZE = 10.0                  !   [m] default = -1.0
                                 ! If HFREEZE > 0, melt potential will be computed. The actual depth over which
                                 ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the

--- a/MOM_input
+++ b/MOM_input
@@ -17,24 +17,9 @@ FATAL_UNUSED_PARAMS = True      !   [Boolean] default = False
 ! This section contains non default layout parameters which are set.
 ! ------------------------
 ! === module MOM_domains ===
-MASKTABLE = "mask_table.1027.72x48" ! default = "MOM_mask_table"
-                                ! A text file to specify n_mask, layout and mask_list. This feature masks out
-                                ! processors that contain only land points. The first line of mask_table is the
-                                ! number of regions to be masked out. The second line is the layout of the model
-                                ! and must be consistent with the actual model layout. The following (n_mask)
-                                ! lines give the logical positions of the processors that are masked out. The
-                                ! mask_table can be created by tools like check_mask. The following example of
-                                ! mask_table masks out 2 processors, (1,2) and (3,6), out of the 24 in a 4x6
-                                ! layout:
-                                !  2
-                                !  4,6
-                                !  1,2
-                                !  3,6
-LAYOUT = 72, 48                 !
-                                ! The processor layout that was actually used.
-IO_LAYOUT = 9, 6                ! default = 1, 1
-                                ! The processor layout to be used, or 0,0 to automatically set the io_layout to
-                                ! be the same as the layout.
+MASKTABLE = "mask_table.4448.96x72"
+LAYOUT = 96, 72
+IO_LAYOUT = 12, 9
 
 ! This section is formatted the same as the MOM_parameter_short.doc output file.
 ! ------------------------
@@ -49,15 +34,20 @@ USE_CONTEMP_ABSSAL = True       !   [Boolean] default = False
 USE_REGRIDDING = True           !   [Boolean] default = False
                                 ! If True, use the ALE algorithm (regridding/remapping). If False, use the
                                 ! layered isopycnal algorithm.
-DT = 900.0                      !   [s]
+THICKNESSDIFFUSE = True         !   [Boolean] default = False
+                                ! If true, isopycnal surfaces are diffused with a Laplacian coefficient of KHTH.
+THICKNESSDIFFUSE_FIRST = True   !   [Boolean] default = False
+                                ! If true, do thickness diffusion or interface height smoothing before dynamics.
+                                ! This is only used if THICKNESSDIFFUSE or APPLY_INTERFACE_FILTER is true.
+DT = 450.0                      !   [s]
                                 ! The (baroclinic) dynamics time step.  The time-step that is actually used will
                                 ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
                                 ! or the coupling timestep in coupled mode.)
-DT_THERM = 7200.0               !   [s] default = 900.0
-                                ! The thermodynamic time step. Ideally DT_THERM should be an integer multiple of
-                                ! DT and of DT_TRACER_ADVECT and less than the forcing or coupling time-step.
-                                ! However, if THERMO_SPANS_COUPLING is true, DT_THERM can be an integer multiple
-                                ! of the coupling timestep. By default DT_THERM is set to DT.
+DT_THERM = 3600.0               !   [s] default = 900.0
+                                ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
+                                ! an integer multiple of DT and less than the forcing or coupling time-step,
+                                ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
+                                ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
 THERMO_SPANS_COUPLING = True    !   [Boolean] default = False
                                 ! If true, the MOM will take thermodynamic timesteps that can be longer than the
                                 ! coupling timestep. The actual thermodynamic timestep that is used in this case
@@ -109,15 +99,17 @@ WRITE_GEOM = 2                  ! default = 1
                                 ! write the geometry and vertical grid files. Other values are invalid.
 GEOM_FILE = "access-om3.mom6.geometry.nc" ! default = "ocean_geometry"
                                 ! The file into which to write the ocean geometry.
+SAVE_INITIAL_CONDS = False       !   [Boolean] default = False
+                                ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 
 ! === module MOM_domains ===
 TRIPOLAR_N = True               !   [Boolean] default = False
                                 ! Use tripolar connectivity at the northern edge of the domain.  With
                                 ! TRIPOLAR_N, NIGLOBAL must be even.
-NIGLOBAL = 1440                 !
+NIGLOBAL = 4320                 !
                                 ! The total number of thickness grid points in the x-direction in the physical
                                 ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
-NJGLOBAL = 1152                 !
+NJGLOBAL = 3672                 !
                                 ! The total number of thickness grid points in the y-direction in the physical
                                 ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
@@ -605,7 +597,7 @@ KAPPA_H2_FACTOR = 0.84          !   [nondim] default = 1.0
 TKE_ITIDE_MAX = 0.1             !   [W m-2] default = 1000.0
                                 ! The maximum internal tide energy source available to mix above the bottom
                                 ! boundary layer with INT_TIDE_DISSIPATION.
-READ_TIDEAMP = True             !   [Boolean] default = False
+READ_TIDEAMP = False             !   [Boolean] default = False
                                 ! If true, read a file (given by TIDEAMP_FILE) containing the tidal amplitude
                                 ! with INT_TIDE_DISSIPATION.
 H2_FILE = "bottom_roughness.nc" !

--- a/MOM_input
+++ b/MOM_input
@@ -39,7 +39,7 @@ THICKNESSDIFFUSE = True         !   [Boolean] default = False
 THICKNESSDIFFUSE_FIRST = True   !   [Boolean] default = False
                                 ! If true, do thickness diffusion or interface height smoothing before dynamics.
                                 ! This is only used if THICKNESSDIFFUSE or APPLY_INTERFACE_FILTER is true.
-DT = 450.0                      !   [s]
+DT = 200.0                      !   [s]
                                 ! The (baroclinic) dynamics time step.  The time-step that is actually used will
                                 ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
                                 ! or the coupling timestep in coupled mode.)

--- a/config.yaml
+++ b/config.yaml
@@ -1,12 +1,12 @@
 # Payu configuration
 
-# If submitting to a different project to your default, uncomment line below 
+# If submitting to a different project to your default, uncomment line below
 # and change project code as appropriate; also set shortpath below
-# project: x77
+project: g40
 # Force payu to always find, and save, files in this scratch project directory
-# shortpath: /scratch/v45
+shortpath: /scratch/x77
 
-# Using payu sync is recommend to copy data from ephemeral scratch space to 
+# Using payu sync is recommend to copy data from ephemeral scratch space to
 # longer term storage
 sync:
     enable: False # set path below and change to true
@@ -16,41 +16,51 @@ sync:
 
 #Model software version
 modules:
-    use:
-        - /g/data/vk83/modules
-    load:
-        - access-om3/2026.03.000
-        - model-tools/mppnccombine-fast/2025.07.000
+  use:
+    - /g/data/vk83/modules
+  load:
+    - access-om3/2025.08.001
 
 queue: normalsr
-ncpus: 2704
+#ncpus: 1664 # 16 nodes
+ncpus: 4992 # 48 nodes
+#ncpus: 3328 # 32 nodes
+#ncpus: 2912 # 28 nodes
 jobfs: 10GB
-mem: 13000GB
-walltime: 6:00:00
-jobname: 25km_jra_ryf
+#mem: 8000GB
+walltime: 05:00:00
+jobname: 8km_jra_ryf
+
+# env:
+#   ESMF_RUNTIME_PROFILE: "on"
+#   ESMF_RUNTIME_TRACE: "on"
+#   ESMF_RUNTIME_PROFILE_OUTPUT: "SUMMARY BINARY"
 
 model: access-om3
 exe: access-om3-MOM6-CICE6
 input:
-    - /g/data/vk83/prerelease/configurations/inputs/access-om3/cice/grids/global.25km/2026.03.16/kmt.nc
-    - /g/data/vk83/configurations/inputs/access-om3/mom/grids/mosaic/global.25km/2025.09.02/ocean_hgrid.nc
-    - /g/data/vk83/prerelease/configurations/inputs/access-om3/mom/grids/vertical/global.25km/2026.03.16/ocean_vgrid.nc
-    - /g/data/vk83/configurations/inputs/access-om3/mom/initial_conditions/global.25km/2025.10.24/woa23_ts_01_mom.nc
-    - /g/data/vk83/configurations/inputs/access-om3/mom/surface_salt_restoring/global.25km/2025.10.24/salt_sfc_restore.nc
-    - /g/data/vk83/prerelease/configurations/inputs/access-om3/mom/tidal_external_files/global.25km/2026.02.26/bottom_roughness.nc
-    - /g/data/vk83/configurations/inputs/access-om3/mom/tidal_external_files/global.25km/2025.09.03/tideamp.nc
-    - /g/data/vk83/prerelease/configurations/inputs/access-om3/share/grids/global.25km/2026.03.16/topog.nc
-    - /g/data/vk83/configurations/inputs/access-om3/mom/chlorophyll/global.25km/2025.11.21/chl_globcolour_monthly_clim.nc
-    - /g/data/vk83/prerelease/configurations/inputs/access-om3/share/meshes/global.25km/2026.03.16/access-om3-25km-ESMFmesh.nc
-    - /g/data/vk83/prerelease/configurations/inputs/access-om3/share/meshes/global.25km/2026.03.16/access-om3-25km-nomask-ESMFmesh.nc
-    - /g/data/vk83/prerelease/configurations/inputs/access-om3/share/meshes/share/2026.01.21/JRA55do-datm-ESMFmesh.nc
-    - /g/data/vk83/prerelease/configurations/inputs/access-om3/share/meshes/share/2026.01.21/JRA55do-drof-ESMFmesh.nc
-    - /g/data/vk83/prerelease/configurations/inputs/access-om3/cmeps/remap_weights/global.25km/2026.03.17/access-om3-25km-rof-remap-weights.nc
-    - /g/data/vk83/prerelease/configurations/inputs/JRA-55/RYF/v1-6/2026.04.15
-    - /g/data/vk83/prerelease/configurations/inputs/access-om3/share/grids/global.25km/2026.02.25/mask_table.1027.72x48
+  # - /g/data/x77/ahg157/inputs/mom6/global-8km/mask_table.2489.72x96
+  # - /g/data/x77/ahg157/inputs/mom6/global-8km/mask_table.1193.48x36
+  # - /g/data/x77/ahg157/inputs/mom6/global-8km/mask_table.2567.72x54
+  - /g/data/x77/ahg157/inputs/mom6/global-8km/mask_table.4448.96x72
+  - /g/data/x77/ahg157/inputs/mom6/global-8km/kmt.nc
+  - /g/data/x77/ahg157/inputs/mom6/global-8km/ocean_hgrid.nc
+  - /g/data/vk83/configurations/inputs/access-om3/mom/grids/vertical/global.25km/2025.03.12/ocean_vgrid.nc
+  - /g/data/x77/ahg157/inputs/mom6/global-8km/topog.nc
+  - /g/data/x77/ahg157/inputs/mom6/global-8km/access-om3-8km-ESMFmesh.nc
+  - /g/data/x77/ahg157/inputs/mom6/global-8km/access-om3-8km-nomask-ESMFmesh.nc
+  - /g/data/x77/ahg157/inputs/mom6/global-8km/access-om3-8km-rof-remap-weights.nc
+  - /g/data/x77/ahg157/inputs/mom6/global-8km/access-om3-8km-vmap-weights.nc
+  - /g/data/vk83/configurations/inputs/JRA-55/RYF/v1-6/data
+  - /g/data/vk83/configurations/inputs/access-om3/share/meshes/share/2024.09.16/JRA55do-datm-ESMFmesh.nc
+  - /g/data/vk83/configurations/inputs/access-om3/share/meshes/share/2024.09.16/JRA55do-drof-ESMFmesh.nc
+  - /g/data/x77/ahg157/inputs/mom6/global-8km/ocean_temp_salt.res.nc
+  - /g/data/x77/ahg157/inputs/mom6/global-8km/salt_sfc_restore.nc
+  - /g/data/x77/ahg157/inputs/mom6/global-8km/bottom_roughness.nc
+  # - /g/data/vk83/configurations/inputs/access-om3/mom/tidal_external_files/global.25km/2025.05.15/tideamp.nc
 
 runlog: true
-metadata: 
+metadata:
     enable: true
 manifest:
   reproduce:
@@ -61,25 +71,24 @@ platform:
     nodesize: 104
     nodemem: 512
 
-mpi:
-  flags:
-  - --mca mpi_yield_when_idle true
+storage:
+  gdata:
+    - x77
 
-collate:
-  restart: true
-  mpi: true
-  walltime: 4:00:00
-  mem: 30GB
-  ncpus: 4
-  queue: normalsr
-  exe: mppnccombine-fast
+collate: false
+# collate:
+#   restart: true
+#   mpi: true
+#   walltime: 1:00:00
+#   mem: 30GB
+#   ncpus: 4
+#   queue: expresssr
+#   exe: /g/data/vk83/apps/mppnccombine-fast/0.2/bin/mppnccombine-fast
 
 userscripts:
     archive: /usr/bin/bash /g/data/vk83/apps/om3-scripts/payu_config/archive.sh
 
 postscript: -v PROJECT,SCRIPTS_DIR=/g/data/vk83/apps/om3-scripts -lstorage=${PBS_NCI_STORAGE}+gdata/xp65 /g/data/vk83/apps/om3-scripts/payu_config/postscript.sh
 
-qsub_flags: -W umask=027
-
-restart_freq: 1YS
-payu_minimum_version: 1.2.0
+#restart_freq: 1YS
+payu_minimum_version: 1.1.7

--- a/config.yaml
+++ b/config.yaml
@@ -52,7 +52,7 @@ input:
   - /g/data/x77/ahg157/inputs/mom6/global-8km/access-om3-8km-nomask-ESMFmesh.nc
   - /g/data/x77/ahg157/inputs/mom6/global-8km/access-om3-8km-rof-remap-weights.nc
   - /g/data/x77/ahg157/inputs/mom6/global-8km/access-om3-8km-vmap-weights.nc
-  - /g/data/vk83/configurations/inputs/JRA-55/RYF/v1-6/data
+  - /g/data/vk83/prerelease/configurations/inputs/JRA-55/RYF/v1-6/2026.04.15
   - /g/data/vk83/configurations/inputs/access-om3/share/meshes/share/2024.09.16/JRA55do-datm-ESMFmesh.nc
   - /g/data/vk83/configurations/inputs/access-om3/share/meshes/share/2024.09.16/JRA55do-drof-ESMFmesh.nc
   - /g/data/x77/ahg157/inputs/mom6/global-8km/ocean_temp_salt.res.nc

--- a/config.yaml
+++ b/config.yaml
@@ -19,7 +19,7 @@ modules:
   use:
     - /g/data/vk83/modules
   load:
-    - access-om3/2025.08.001
+    - access-om3/2026.03.000
     - model-tools/mppnccombine-fast/2025.07.000
 
 queue: normalsr
@@ -63,13 +63,11 @@ input:
   #
   #
   - /g/data/tm70/ek4684/8km_grid_input_files/chl_globcolour_monthly_clim.nc
+  - /g/data/tm70/ek4684/8km_grid_input_files/B_mask_8km.nc
   #
   - /g/data/tm70/ek4684/8km_grid_input_files/access-om3-8km-rofi-climatology.nc
-  - /g/data/tm70/ek4684/8km_grid_input_files/B_mask_8km.nc
-  - /g/data/tm70/ek4684/8km_grid_input_files/bottom_roughness_intermediate.nc
   - /g/data/tm70/ek4684/8km_grid_input_files/CO2_gm_1750-2024.nc
   - /g/data/tm70/ek4684/8km_grid_input_files/SFe_Hamiltonetal2020_monthly_clim.nc
-  - /g/data/tm70/ek4684/8km_grid_input_files/temp_weights.nc
   - /g/data/tm70/ek4684/8km_grid_input_files/tideamp.nc
 
 runlog: False

--- a/config.yaml
+++ b/config.yaml
@@ -20,6 +20,7 @@ modules:
     - /g/data/vk83/modules
   load:
     - access-om3/2025.08.001
+    - model-tools/mppnccombine-fast/2025.07.000
 
 queue: normalsr
 #ncpus: 1664 # 16 nodes
@@ -75,15 +76,14 @@ storage:
   gdata:
     - x77
 
-collate: false
-# collate:
-#   restart: true
-#   mpi: true
-#   walltime: 1:00:00
-#   mem: 30GB
-#   ncpus: 4
-#   queue: expresssr
-#   exe: /g/data/vk83/apps/mppnccombine-fast/0.2/bin/mppnccombine-fast
+collate:
+  restart: true
+  mpi: true
+  walltime: 4:00:00
+  mem: 30GB
+  ncpus: 4
+  queue: normalsr
+  exe: mppnccombine-fast
 
 userscripts:
     archive: /usr/bin/bash /g/data/vk83/apps/om3-scripts/payu_config/archive.sh

--- a/config.yaml
+++ b/config.yaml
@@ -79,7 +79,9 @@ platform:
 
 storage:
   gdata:
-    - x77
+    - tm70
+    - vk83
+#    - x77
 
 collate:
   restart: true

--- a/config.yaml
+++ b/config.yaml
@@ -44,21 +44,33 @@ input:
   # - /g/data/x77/ahg157/inputs/mom6/global-8km/mask_table.1193.48x36
   # - /g/data/x77/ahg157/inputs/mom6/global-8km/mask_table.2567.72x54
   - /g/data/x77/ahg157/inputs/mom6/global-8km/mask_table.4448.96x72
-  - /g/data/x77/ahg157/inputs/mom6/global-8km/kmt.nc
-  - /g/data/x77/ahg157/inputs/mom6/global-8km/ocean_hgrid.nc
-  - /g/data/vk83/configurations/inputs/access-om3/mom/grids/vertical/global.25km/2025.03.12/ocean_vgrid.nc
-  - /g/data/x77/ahg157/inputs/mom6/global-8km/topog.nc
-  - /g/data/x77/ahg157/inputs/mom6/global-8km/access-om3-8km-ESMFmesh.nc
-  - /g/data/x77/ahg157/inputs/mom6/global-8km/access-om3-8km-nomask-ESMFmesh.nc
-  - /g/data/x77/ahg157/inputs/mom6/global-8km/access-om3-8km-rof-remap-weights.nc
+  - /g/data/tm70/ek4684/8km_grid_input_files/kmt.nc
+  - /g/data/tm70/ek4684/8km_grid_input_files/ocean_hgrid.nc
+  - /g/data/tm70/ek4684/8km_grid_input_files/ocean_vgrid.nc
+  - /g/data/tm70/ek4684/8km_grid_input_files/topog.nc
+  - /g/data/tm70/ek4684/8km_grid_input_files/access-om3-8km-ESMFmesh.nc
+  - /g/data/tm70/ek4684/8km_grid_input_files/access-om3-8km-nomask-ESMFmesh.nc
+  - /g/data/tm70/ek4684/8km_grid_input_files/access-om3-8km-rof-remap-weights.nc
   - /g/data/x77/ahg157/inputs/mom6/global-8km/access-om3-8km-vmap-weights.nc
   - /g/data/vk83/prerelease/configurations/inputs/JRA-55/RYF/v1-6/2026.04.15
-  - /g/data/vk83/configurations/inputs/access-om3/share/meshes/share/2024.09.16/JRA55do-datm-ESMFmesh.nc
-  - /g/data/vk83/configurations/inputs/access-om3/share/meshes/share/2024.09.16/JRA55do-drof-ESMFmesh.nc
-  - /g/data/x77/ahg157/inputs/mom6/global-8km/ocean_temp_salt.res.nc
-  - /g/data/x77/ahg157/inputs/mom6/global-8km/salt_sfc_restore.nc
-  - /g/data/x77/ahg157/inputs/mom6/global-8km/bottom_roughness.nc
+  - /g/data/vk83/prerelease/configurations/inputs/access-om3/share/meshes/share/2026.01.21/JRA55do-datm-ESMFmesh.nc
+  - /g/data/vk83/prerelease/configurations/inputs/access-om3/share/meshes/share/2026.01.21/JRA55do-drof-ESMFmesh.nc
+  - /g/data/tm70/cyb561/8km_woa_ic/woa23_ts_01_mom.nc
+  - /g/data/tm70/ek4684/8km_grid_input_files/salt_sfc_restore.nc
+  - /g/data/tm70/ek4684/8km_grid_input_files/bottom_roughness.nc
   # - /g/data/vk83/configurations/inputs/access-om3/mom/tidal_external_files/global.25km/2025.05.15/tideamp.nc
+  #
+  #
+  #
+  - /g/data/tm70/ek4684/8km_grid_input_files/chl_globcolour_monthly_clim.nc
+  #
+  - /g/data/tm70/ek4684/8km_grid_input_files/access-om3-8km-rofi-climatology.nc
+  - /g/data/tm70/ek4684/8km_grid_input_files/B_mask_8km.nc
+  - /g/data/tm70/ek4684/8km_grid_input_files/bottom_roughness_intermediate.nc
+  - /g/data/tm70/ek4684/8km_grid_input_files/CO2_gm_1750-2024.nc
+  - /g/data/tm70/ek4684/8km_grid_input_files/SFe_Hamiltonetal2020_monthly_clim.nc
+  - /g/data/tm70/ek4684/8km_grid_input_files/temp_weights.nc
+  - /g/data/tm70/ek4684/8km_grid_input_files/tideamp.nc
 
 runlog: False
 metadata:

--- a/config.yaml
+++ b/config.yaml
@@ -40,10 +40,7 @@ jobname: 8km_jra_ryf
 model: access-om3
 exe: access-om3-MOM6-CICE6
 input:
-  # - /g/data/x77/ahg157/inputs/mom6/global-8km/mask_table.2489.72x96
-  # - /g/data/x77/ahg157/inputs/mom6/global-8km/mask_table.1193.48x36
-  # - /g/data/x77/ahg157/inputs/mom6/global-8km/mask_table.2567.72x54
-  - /g/data/x77/ahg157/inputs/mom6/global-8km/mask_table.4448.96x72
+  - /g/data/tm70/ek4684/8km_grid_input_files/mask_table.4448.96x72
   - /g/data/tm70/ek4684/8km_grid_input_files/kmt.nc
   - /g/data/tm70/ek4684/8km_grid_input_files/ocean_hgrid.nc
   - /g/data/tm70/ek4684/8km_grid_input_files/ocean_vgrid.nc
@@ -51,7 +48,7 @@ input:
   - /g/data/tm70/ek4684/8km_grid_input_files/access-om3-8km-ESMFmesh.nc
   - /g/data/tm70/ek4684/8km_grid_input_files/access-om3-8km-nomask-ESMFmesh.nc
   - /g/data/tm70/ek4684/8km_grid_input_files/access-om3-8km-rof-remap-weights.nc
-  - /g/data/x77/ahg157/inputs/mom6/global-8km/access-om3-8km-vmap-weights.nc
+  - /g/data/tm70/ek4684/8km_grid_input_files/access-om3-8km-vmap-weights.nc
   - /g/data/vk83/prerelease/configurations/inputs/JRA-55/RYF/v1-6/2026.04.15
   - /g/data/vk83/prerelease/configurations/inputs/access-om3/share/meshes/share/2026.01.21/JRA55do-datm-ESMFmesh.nc
   - /g/data/vk83/prerelease/configurations/inputs/access-om3/share/meshes/share/2026.01.21/JRA55do-drof-ESMFmesh.nc
@@ -59,17 +56,15 @@ input:
   - /g/data/tm70/ek4684/8km_grid_input_files/salt_sfc_restore.nc
   - /g/data/tm70/ek4684/8km_grid_input_files/bottom_roughness.nc
   # - /g/data/vk83/configurations/inputs/access-om3/mom/tidal_external_files/global.25km/2025.05.15/tideamp.nc
-  #
-  #
-  #
   - /g/data/tm70/ek4684/8km_grid_input_files/chl_globcolour_monthly_clim.nc
-  - /g/data/tm70/ek4684/8km_grid_input_files/B_mask_8km.nc
-  #
   - /g/data/tm70/ek4684/8km_grid_input_files/access-om3-8km-rofi-climatology.nc
-  - /g/data/tm70/ek4684/8km_grid_input_files/CO2_gm_1750-2024.nc
-  - /g/data/tm70/ek4684/8km_grid_input_files/SFe_Hamiltonetal2020_monthly_clim.nc
   - /g/data/tm70/ek4684/8km_grid_input_files/tideamp.nc
 
+  #Likely not needed...
+  # - /g/data/tm70/ek4684/8km_grid_input_files/B_mask_8km.nc
+  #- /g/data/tm70/ek4684/8km_grid_input_files/CO2_gm_1750-2024.nc
+  #- /g/data/tm70/ek4684/8km_grid_input_files/SFe_Hamiltonetal2020_monthly_clim.nc
+  
 runlog: False
 metadata:
     enable: true

--- a/config.yaml
+++ b/config.yaml
@@ -90,5 +90,6 @@ userscripts:
 
 postscript: -v PROJECT,SCRIPTS_DIR=/g/data/vk83/apps/om3-scripts -lstorage=${PBS_NCI_STORAGE}+gdata/xp65 /g/data/vk83/apps/om3-scripts/payu_config/postscript.sh
 
+qsub_flags: -W umask=027
 #restart_freq: 1YS
 payu_minimum_version: 1.1.7

--- a/config.yaml
+++ b/config.yaml
@@ -19,7 +19,7 @@ modules:
   use:
     - /g/data/vk83/modules
   load:
-    - access-om3/2026.03.000
+    - access-om3/2026.05.002
     - model-tools/mppnccombine-fast/2025.07.000
 
 queue: normalsr

--- a/config.yaml
+++ b/config.yaml
@@ -2,9 +2,9 @@
 
 # If submitting to a different project to your default, uncomment line below
 # and change project code as appropriate; also set shortpath below
-project: g40
+project: tm70
 # Force payu to always find, and save, files in this scratch project directory
-shortpath: /scratch/x77
+shortpath: /scratch/tm70
 
 # Using payu sync is recommend to copy data from ephemeral scratch space to
 # longer term storage
@@ -59,13 +59,13 @@ input:
   - /g/data/x77/ahg157/inputs/mom6/global-8km/bottom_roughness.nc
   # - /g/data/vk83/configurations/inputs/access-om3/mom/tidal_external_files/global.25km/2025.05.15/tideamp.nc
 
-runlog: true
+runlog: False
 metadata:
     enable: true
 manifest:
   reproduce:
-    exe: True
-    input: True
+    exe: False
+    input: False
 
 platform:
     nodesize: 104

--- a/datm_in
+++ b/datm_in
@@ -7,10 +7,10 @@
   flds_presndep = .false.
   flds_preso3 = .false.
   iradsw = 1
-  model_maskfile = "./INPUT/access-om3-25km-nomask-ESMFmesh.nc"
-  model_meshfile = "./INPUT/access-om3-25km-nomask-ESMFmesh.nc"
-  nx_global = 1440
-  ny_global = 1152
+  model_maskfile = "./INPUT/access-om3-8km-nomask-ESMFmesh.nc"
+  model_meshfile = "./INPUT/access-om3-8km-nomask-ESMFmesh.nc"
+  nx_global = 4320
+  ny_global = 3672
   restfilm = "null"
   skip_restart_read = .false.
 /

--- a/drof_in
+++ b/drof_in
@@ -1,9 +1,9 @@
 &drof_nml
   datamode = "copyall"
-  model_maskfile = "./INPUT/access-om3-25km-nomask-ESMFmesh.nc"
-  model_meshfile = "./INPUT/access-om3-25km-nomask-ESMFmesh.nc"
-  nx_global = 1440
-  ny_global = 1152
+  model_maskfile = "./INPUT/access-om3-8km-nomask-ESMFmesh.nc"
+  model_meshfile = "./INPUT/access-om3-8km-nomask-ESMFmesh.nc"
+  nx_global = 4320
+  ny_global = 3672
   restfilm = "null"
   skip_restart_read = .false.
 /

--- a/ice_in
+++ b/ice_in
@@ -68,8 +68,8 @@
   ustar_min = 0.0005
 /
 &domain_nml
-  block_size_x = 30
-  block_size_y = 27
+  block_size_x = 60
+  block_size_y = 54
   distribution_type = "roundrobin"
   distribution_wght = "latitude"
   maskhalo_bound = .true.
@@ -77,8 +77,8 @@
   maskhalo_remap = .true.
   max_blocks = -1
   ns_boundary_type = "tripole"
-  nx_global = 1440
-  ny_global = 1152
+  nx_global = 4320
+  ny_global = 3672
   processor_shape = "square-ice"
 /
 &ice_prescribed_nml

--- a/manifests/exe.yaml
+++ b/manifests/exe.yaml
@@ -2,7 +2,7 @@ format: yamanifest
 version: 1.0
 ---
 work/access-om3-MOM6-CICE6:
-  fullpath: /g/data/vk83/apps/spack/1.1/release/linux-x86_64_v4/access3-2026.03.000-vwmpe5wrm4xa6kcftryzok5nu3iexzyb/bin/access-om3-MOM6-CICE6
+  fullpath: /g/data/vk83/apps/spack/0.22/release/linux-rocky8-x86_64_v4/oneapi-2025.2.0/access3-2025.08.000-n2qsfzdl7syl4k6m4dx3ydqxarpkmw6l/bin/access-om3-MOM6-CICE6
   hashes:
-    binhash: 38b5b571d82d469e4fd0d3e5737d344a
-    md5: e47699829d0db550143c7b1ec1efe104
+    binhash: 2c767b4b07ae2e86e21b4a50582de8df
+    md5: cda3625020745cae76fcfc1f800ef4b3

--- a/manifests/input.yaml
+++ b/manifests/input.yaml
@@ -2,132 +2,127 @@ format: yamanifest
 version: 1.0
 ---
 work/INPUT/JRA55do-datm-ESMFmesh.nc:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-om3/share/meshes/share/2026.01.21/JRA55do-datm-ESMFmesh.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-om3/share/meshes/share/2024.09.16/JRA55do-datm-ESMFmesh.nc
   hashes:
-    binhash: c0e9a071f20670930d0e117f13399d78
-    md5: 0ecb68f878b91b8adc90838e2c413914
+    binhash: 3aa7bd11a69390ed8739af63e41462fd
+    md5: f583b0fc505afc28f1d7c949a715cccb
 work/INPUT/JRA55do-drof-ESMFmesh.nc:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-om3/share/meshes/share/2026.01.21/JRA55do-drof-ESMFmesh.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-om3/share/meshes/share/2024.09.16/JRA55do-drof-ESMFmesh.nc
   hashes:
-    binhash: 9f3ee3ce42e776fcbee8026e0c3880f5
-    md5: bf62c4e7786ddfbe56d61b3074d5d16d
+    binhash: fa1322dbc0ab951527b165f8327c7b5b
+    md5: 3b46260b8c14d12925cf70f82da6658e
 work/INPUT/RYF.friver.1990_1991.nc:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/JRA-55/RYF/v1-6/2026.04.15/RYF.friver.1990_1991.nc
+  fullpath: /g/data/vk83/configurations/inputs/JRA-55/RYF/v1-6/data/RYF.friver.1990_1991.nc
   hashes:
-    binhash: eb2c39ab9384638e11ea50c7f809e8f0
-    md5: beb16730c02db9a730f69dfdc843b774
+    binhash: 7ed1b4267c202eae4e1e1fb7170adfdc
+    md5: 06d549192558fc48c43416b1015044bc
 work/INPUT/RYF.huss.1990_1991.nc:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/JRA-55/RYF/v1-6/2026.04.15/RYF.huss.1990_1991.nc
+  fullpath: /g/data/vk83/configurations/inputs/JRA-55/RYF/v1-6/data/RYF.huss.1990_1991.nc
   hashes:
-    binhash: ea3f553f869d4654691085f1d99986e3
-    md5: 1b184b232a31382443e5818bb623a9cb
+    binhash: be1a71017ed8b5392505b2b013e05343
+    md5: 76bce15820d66e4dbd55674072253869
 work/INPUT/RYF.licalvf.1990_1991.nc:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/JRA-55/RYF/v1-6/2026.04.15/RYF.licalvf.1990_1991.nc
+  fullpath: /g/data/vk83/configurations/inputs/JRA-55/RYF/v1-6/data/RYF.licalvf.1990_1991.nc
   hashes:
-    binhash: eefaf66dfc5524f47e0906d51964df0d
-    md5: 1d9233a590fb94d052196cdd5245a585
+    binhash: e7eb183d2b7cdd685bdee810004cf3c9
+    md5: 33aba38d6bffb45f9b1ce6240c2cd21a
 work/INPUT/RYF.prra.1990_1991.nc:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/JRA-55/RYF/v1-6/2026.04.15/RYF.prra.1990_1991.nc
+  fullpath: /g/data/vk83/configurations/inputs/JRA-55/RYF/v1-6/data/RYF.prra.1990_1991.nc
   hashes:
-    binhash: 94d00a3d55795feb6ecd8012773430af
-    md5: a03d5b51f44fb9fcad5036a0b7d408d0
+    binhash: 1d8af8b1b94d1cf78a3108477d329d06
+    md5: 4e1210fa78c124c1537e8ce28584555c
 work/INPUT/RYF.prsn.1990_1991.nc:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/JRA-55/RYF/v1-6/2026.04.15/RYF.prsn.1990_1991.nc
+  fullpath: /g/data/vk83/configurations/inputs/JRA-55/RYF/v1-6/data/RYF.prsn.1990_1991.nc
   hashes:
-    binhash: 6c6b6395026404e39e67a7211753e875
-    md5: 914dcf6080c0fc9b9d46bf7082a4c0be
+    binhash: 5b9d401daa0c90298d703a3a2dac12b1
+    md5: 1fa60bceab287d4059c6a23d5fb18170
 work/INPUT/RYF.psl.1990_1991.nc:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/JRA-55/RYF/v1-6/2026.04.15/RYF.psl.1990_1991.nc
+  fullpath: /g/data/vk83/configurations/inputs/JRA-55/RYF/v1-6/data/RYF.psl.1990_1991.nc
   hashes:
-    binhash: e3bdf90e84b1e8e75bebbc83a4bd698a
-    md5: 98206e380baf0f229b2983f569f9b0e0
+    binhash: e85798bf489561d1eb316a50b170f318
+    md5: 40003042b732f70edaf59f302427b213
 work/INPUT/RYF.rlds.1990_1991.nc:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/JRA-55/RYF/v1-6/2026.04.15/RYF.rlds.1990_1991.nc
+  fullpath: /g/data/vk83/configurations/inputs/JRA-55/RYF/v1-6/data/RYF.rlds.1990_1991.nc
   hashes:
-    binhash: 7a036494befa912be20ff81830cf5f8f
-    md5: 6e9242d3a02c1ee768337dcab710de39
+    binhash: 33502887b018dbb288775102c1411d65
+    md5: 449ca4bd2d51794204a6ceedc79bad82
 work/INPUT/RYF.rsds.1990_1991.nc:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/JRA-55/RYF/v1-6/2026.04.15/RYF.rsds.1990_1991.nc
+  fullpath: /g/data/vk83/configurations/inputs/JRA-55/RYF/v1-6/data/RYF.rsds.1990_1991.nc
   hashes:
-    binhash: 6c148adc1bee28c556b767a12c9538ad
-    md5: 5f9721311ff7ac4908ca79a9d9cfa5fd
+    binhash: ca831af4d8931736138d04166910b7c4
+    md5: 7d8e5270940eaaf5121b72eea736b2cd
 work/INPUT/RYF.tas.1990_1991.nc:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/JRA-55/RYF/v1-6/2026.04.15/RYF.tas.1990_1991.nc
+  fullpath: /g/data/vk83/configurations/inputs/JRA-55/RYF/v1-6/data/RYF.tas.1990_1991.nc
   hashes:
-    binhash: 6711ed881a4f0973794d1adbec4c80f3
-    md5: 5fdf6d3b0369f1b50138013101c288a6
+    binhash: ae172b9c06fe1b5b2b0a2b78e7de0d17
+    md5: 1947327fb37d4d1e7eee3e1804500721
 work/INPUT/RYF.uas.1990_1991.nc:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/JRA-55/RYF/v1-6/2026.04.15/RYF.uas.1990_1991.nc
+  fullpath: /g/data/vk83/configurations/inputs/JRA-55/RYF/v1-6/data/RYF.uas.1990_1991.nc
   hashes:
-    binhash: 9fe296a0b9aab65aa6a39d9205357454
-    md5: 264a82753021ba094b54cc0cfae4f3ec
+    binhash: 7271b6b617e233932c5e319a63c64bc3
+    md5: 74516d793e148d522b2b2f73eb6eb6c7
 work/INPUT/RYF.vas.1990_1991.nc:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/JRA-55/RYF/v1-6/2026.04.15/RYF.vas.1990_1991.nc
+  fullpath: /g/data/vk83/configurations/inputs/JRA-55/RYF/v1-6/data/RYF.vas.1990_1991.nc
   hashes:
-    binhash: 32c97e6ab7f375008a45dbd3dae259f8
-    md5: bd0ccd8ef7f639ca77b6705f0d6d1fcb
-work/INPUT/access-om3-25km-ESMFmesh.nc:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-om3/share/meshes/global.25km/2026.03.16/access-om3-25km-ESMFmesh.nc
+    binhash: f353a71a014062723ed2b56353932caf
+    md5: 30b92b1e409cff9a9900692aa961aba4
+work/INPUT/access-om3-8km-ESMFmesh.nc:
+  fullpath: /g/data/x77/ahg157/inputs/mom6/global-8km/access-om3-8km-ESMFmesh.nc
   hashes:
-    binhash: 18acce9cbe9589b0edfa466cf0fa01fc
-    md5: 02ad0cfc5574ec65bc912e8b5535108f
-work/INPUT/access-om3-25km-nomask-ESMFmesh.nc:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-om3/share/meshes/global.25km/2026.03.16/access-om3-25km-nomask-ESMFmesh.nc
+    binhash: a9740a484e7e9a729dcdc9f82dbab77d
+    md5: 483db5b68e183914369582dad689a1c6
+work/INPUT/access-om3-8km-nomask-ESMFmesh.nc:
+  fullpath: /g/data/x77/ahg157/inputs/mom6/global-8km/access-om3-8km-nomask-ESMFmesh.nc
   hashes:
-    binhash: 1f20f742929793f3f85eabaa988e1afe
-    md5: 0a5d43e0b6da1f8236ef69cd8f4b21a1
-work/INPUT/access-om3-25km-rof-remap-weights.nc:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-om3/cmeps/remap_weights/global.25km/2026.03.17/access-om3-25km-rof-remap-weights.nc
+    binhash: ae38ec873cd05a4e84656dfa7831c1cd
+    md5: 58c30e0a380ef7ffd857dd27c54d3892
+work/INPUT/access-om3-8km-rof-remap-weights.nc:
+  fullpath: /g/data/x77/ahg157/inputs/mom6/global-8km/access-om3-8km-rof-remap-weights.nc
   hashes:
-    binhash: 5d50138723dc4e7027d6dccff99010fe
-    md5: 0ba2c5582c2e5daff1842995718e3432
+    binhash: 169f0071669815edae26b82a2df3d926
+    md5: 9b8c9f7f294ffd2283a09cbb7a07f48b
+work/INPUT/access-om3-8km-vmap-weights.nc:
+  fullpath: /g/data/x77/ahg157/inputs/mom6/global-8km/access-om3-8km-vmap-weights.nc
+  hashes:
+    binhash: d579cfcc5df8acefe81476d6c43f9826
+    md5: c2eb7d65432e728a3d519f37bfcf6892
 work/INPUT/bottom_roughness.nc:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-om3/mom/tidal_external_files/global.25km/2026.02.26/bottom_roughness.nc
+  fullpath: /g/data/x77/ahg157/inputs/mom6/global-8km/bottom_roughness.nc
   hashes:
-    binhash: b712549af1156b76c5fd458e5dae0e58
-    md5: 9788689ef81213734a354cd59ce81386
-work/INPUT/chl_globcolour_monthly_clim.nc:
-  fullpath: /g/data/vk83/configurations/inputs/access-om3/mom/chlorophyll/global.25km/2025.11.21/chl_globcolour_monthly_clim.nc
-  hashes:
-    binhash: f30a3f69bee2f2174596d238e1de822e
-    md5: 269f4492ae65f6ef9dd6e2a59f2bff4b
+    binhash: bc59de9339d10035cac71ceba76dd542
+    md5: 1dfab48c6276d7ce7525c199d9183a33
 work/INPUT/kmt.nc:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-om3/cice/grids/global.25km/2026.03.16/kmt.nc
+  fullpath: /g/data/x77/ahg157/inputs/mom6/global-8km/kmt.nc
   hashes:
-    binhash: 93ba165d4a0a8955dd0e7979d25fefe3
-    md5: f6c68bcc4ffa588787aeac108d655d18
-work/INPUT/mask_table.1027.72x48:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-om3/share/grids/global.25km/2026.02.25/mask_table.1027.72x48
+    binhash: 0fff96657f4906e04dd1118c484593c1
+    md5: e0ead34b617a8c909e0f82c11e14a913
+work/INPUT/mask_table.4448.96x72:
+  fullpath: /g/data/x77/ahg157/inputs/mom6/global-8km/mask_table.4448.96x72
   hashes:
-    binhash: b854b81785867b187ca9e2b7b5c55fd3
-    md5: e100dd283b19233f9a412a876d328b7e
+    binhash: 744148f724498669516454e55ef7271d
+    md5: 41926095b76013b740411916ce4d0303
 work/INPUT/ocean_hgrid.nc:
-  fullpath: /g/data/vk83/configurations/inputs/access-om3/mom/grids/mosaic/global.25km/2025.09.02/ocean_hgrid.nc
+  fullpath: /g/data/x77/ahg157/inputs/mom6/global-8km/ocean_hgrid.nc
   hashes:
-    binhash: a7882fb994abd0e402809e39545dc2c5
-    md5: dd9cb78712fedbdd3e5930f7066bcac8
+    binhash: e101cd4d49c425755f0e100799a09cf6
+    md5: 257e9fd6e2fbc21ae401dcac05e0541d
+work/INPUT/ocean_temp_salt.res.nc:
+  fullpath: /g/data/x77/ahg157/inputs/mom6/global-8km/ocean_temp_salt.res.nc
+  hashes:
+    binhash: 2d6092916c78984389c18713347d074a
+    md5: 26bdc77845852fa7fb67d662d4067812
 work/INPUT/ocean_vgrid.nc:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-om3/mom/grids/vertical/global.25km/2026.03.16/ocean_vgrid.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-om3/mom/grids/vertical/global.25km/2025.03.12/ocean_vgrid.nc
   hashes:
-    binhash: a50dfc9f3216a3dbb32c2b32f2fce4b2
-    md5: 04e88652ff339b09b29ea4adb8fa2229
+    binhash: cbc588e29d819ce8898d77760a65e20d
+    md5: 66f71f2b24bd00b1c220787505e0106e
 work/INPUT/salt_sfc_restore.nc:
-  fullpath: /g/data/vk83/configurations/inputs/access-om3/mom/surface_salt_restoring/global.25km/2025.10.24/salt_sfc_restore.nc
+  fullpath: /g/data/x77/ahg157/inputs/mom6/global-8km/salt_sfc_restore.nc
   hashes:
-    binhash: 54166d28383dfc561138638479cec1db
-    md5: 0e59f79a3da9a989eb9ce854277599f8
-work/INPUT/tideamp.nc:
-  fullpath: /g/data/vk83/configurations/inputs/access-om3/mom/tidal_external_files/global.25km/2025.09.03/tideamp.nc
-  hashes:
-    binhash: 0b69afaa564866597b1232be5ec00dad
-    md5: 1aa1db4e7b14f0486d3546b9bc2a035a
+    binhash: 7e8d6919538c569e2c17b58c920513fc
+    md5: 8be892b8b36211ab587bbdb28290435f
 work/INPUT/topog.nc:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-om3/share/grids/global.25km/2026.03.16/topog.nc
+  fullpath: /g/data/x77/ahg157/inputs/mom6/global-8km/topog.nc
   hashes:
-    binhash: 656d64ead52edbf14cafb0b85c19685e
-    md5: 9381628f3d0fe4d0c6965e1c7b7af3c6
-work/INPUT/woa23_ts_01_mom.nc:
-  fullpath: /g/data/vk83/configurations/inputs/access-om3/mom/initial_conditions/global.25km/2025.10.24/woa23_ts_01_mom.nc
-  hashes:
-    binhash: a56e68e159c8007dd75cfa3d2d22cb6c
-    md5: bd9559e8a3dbefa16080d0340b26be12
+    binhash: 8740a0d404421393e773c17e61a51958
+    md5: 362529f0412c7fe6c69c332a357c2fc9

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,6 +1,6 @@
-contact: Add your name here
-email: Add your email address here
-created: Add the date you started the experiment here (YYYY-MM-DD)
+contact: Angus Gibson
+email: angus@agibson.me
+created: '2025-10-30'
 description: |-
     25km ACCESS-OM3 global configuration under the RYF9091 Repeat
     Year Forcing strategy outlined by Stewart et al (2020), 
@@ -13,15 +13,17 @@ notes: |-
   following the examples at https://www.access-nri.org.au/resources/acknowledging-us/ 
   and https://cosima.org.au/index.php/get-involved/
 keywords:
-  - JRA55
-  - access-om3
-  - repeat-year
-  - global
+- JRA55
+- access-om3
+- repeat-year
+- global
 realm:
-  - ocean
-  - seaIce
+- ocean
+- seaIce
 nominal_resolution: 25 km
 license: CC-BY-4.0
 model: ACCESS-OM3
-url: https://github.com/ACCESS-NRI/access-om3-configs/tree/release-MC_25km_jra_ryf
+url: https://github.com/access-nri/access-om3-configs
 version: 1.0-beta
+experiment_uuid: 3758ae6d-2238-46f8-835f-5e1ff0291392
+name: 20250826-global-8km-angus-g/global-8km-3758ae6d

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,13 +1,13 @@
-contact: Angus Gibson
-email: angus@agibson.me
-created: '2025-10-30'
+contact: Christopher Bull
+email: 5499680+chrisb13@users.noreply.github.com
+created: '2026-05-17'
 description: |-
-    25km ACCESS-OM3 global configuration under the RYF9091 Repeat
-    Year Forcing strategy outlined by Stewart et al (2020), 
-    https://doi.org/10.1016/j.ocemod.2019.101557.
-    Initial conditions of temperature and salinity are from WOA23.
-    Run with JRA55-do v1.6.0 RYF9091 (1 May 1990 - 30 April 1991) repeated forcing.
-    Spin up starts from a nominal year of 1 Jan 1900.
+  25km ACCESS-OM3 global configuration under the RYF9091 Repeat
+  Year Forcing strategy outlined by Stewart et al (2020), 
+  https://doi.org/10.1016/j.ocemod.2019.101557.
+  Initial conditions of temperature and salinity are from WOA23.
+  Run with JRA55-do v1.6.0 RYF9091 (1 May 1990 - 30 April 1991) repeated forcing.
+  Spin up starts from a nominal year of 1 Jan 1900.
 notes: |-
   ACCESS-NRI and COSIMA request that users of this model acknowledge those organisations 
   following the examples at https://www.access-nri.org.au/resources/acknowledging-us/ 
@@ -23,7 +23,7 @@ realm:
 nominal_resolution: 25 km
 license: CC-BY-4.0
 model: ACCESS-OM3
-url: https://github.com/access-nri/access-om3-configs
+url: https://github.com/chrisb13/access-om3-configs
 version: 1.0-beta
-experiment_uuid: 3758ae6d-2238-46f8-835f-5e1ff0291392
-name: 20250826-global-8km-angus-g/global-8km-3758ae6d
+experiment_uuid: 2b5d28e2-abc0-4987-8ea3-e7f5e485b762
+name: dev-MC_8km_jra_ryf-dev-MC_8km_jra_ryf-2b5d28e2

--- a/nuopc.runconfig
+++ b/nuopc.runconfig
@@ -1,5 +1,5 @@
 DRIVER_attributes::
-     Verbosity = off
+     Verbosity = high
      cime_model = cesm
      drv_restart_pointer = rpointer.cpl
      logFilePostFix = .log
@@ -27,28 +27,28 @@ DRIVER_attributes::
 ::
 
 PELAYOUT_attributes::
-     atm_ntasks = 275
+     atm_ntasks = 544
      atm_nthreads = 1
      atm_pestride = 1
      atm_rootpe = 0
-     cpl_ntasks = 275
+     cpl_ntasks = 544
      cpl_nthreads = 1
      cpl_pestride = 1
      cpl_rootpe = 0
      esmf_logging = ESMF_LOGKIND_NONE
-     ice_ntasks = 275
+     ice_ntasks = 544
      ice_nthreads = 1
      ice_pestride = 1
      ice_rootpe = 0
      ninst = 1
-     ocn_ntasks = 2429
+     ocn_ntasks = 4448
      ocn_nthreads = 1
      ocn_pestride = 1
-     ocn_rootpe = 275
+     ocn_rootpe = 544
      pio_asyncio_ntasks = 0
      pio_asyncio_rootpe = 1
      pio_asyncio_stride = 0
-     rof_ntasks = 275
+     rof_ntasks = 544
      rof_nthreads = 1
      rof_pestride = 1
      rof_rootpe = 0
@@ -98,11 +98,11 @@ ALLCOMP_attributes::
      hostname = gadi
      ice_ncat = 5
      mediator_present = true
-     mesh_atm = ./INPUT/access-om3-25km-ESMFmesh.nc
-     mesh_ice = ./INPUT/access-om3-25km-ESMFmesh.nc
+     mesh_atm = ./INPUT/access-om3-8km-ESMFmesh.nc
+     mesh_ice = ./INPUT/access-om3-8km-ESMFmesh.nc
      mesh_lnd = UNSET
-     mesh_mask = ./INPUT/access-om3-25km-ESMFmesh.nc
-     mesh_ocn = ./INPUT/access-om3-25km-ESMFmesh.nc
+     mesh_mask = ./INPUT/access-om3-8km-ESMFmesh.nc
+     mesh_ocn = ./INPUT/access-om3-8km-ESMFmesh.nc
      model_version = unknown
      ocn2glc_coupling = .false.
      ocn2glc_levels = 1:10:19:26:30:33:35
@@ -122,14 +122,14 @@ ALLCOMP_attributes::
 ::
 
 MED_attributes::
-     Verbosity = off
+     Verbosity = high
      aoflux_grid = ogrid
-     atm2ice_map = unset
+     atm2ice_map = ./INPUT/access-om3-8km-vmap-weights.nc
      atm2lnd_map = unset
-     atm2ocn_map = unset
+     atm2ocn_map = ./INPUT/access-om3-8km-vmap-weights.nc
      atm2wav_map = unset
-     atm_nx = 1440
-     atm_ny = 1152
+     atm_nx = 4320
+     atm_ny = 3672
      budget_ann = 1
      budget_daily = 0
      budget_inst = 0
@@ -234,9 +234,9 @@ MED_attributes::
      history_option_wav_inst = never
      ice2atm_map = unset
      ice2wav_smapname = unset
-     ice_nx = 1440
-     ice_ny = 1152
-     info_debug = 1
+     ice_nx = 4320
+     ice_ny = 3672
+     info_debug = 2
      lnd2atm_map = unset
      lnd2rof_map = unset
      lnd_nx = 0
@@ -244,15 +244,15 @@ MED_attributes::
      mapuv_with_cart3d = .true.
      ocn2atm_map = unset
      ocn2wav_smapname = unset
-     ocn_nx = 1440
-     ocn_ny = 1152
+     ocn_nx = 4320
+     ocn_ny = 3672
      ocn_surface_flux_scheme = 0
      rof2lnd_map = unset
      rof2ocn_fmapname = unset
-     rof2ocn_ice_rmapname = ./INPUT/access-om3-25km-rof-remap-weights.nc
-     rof2ocn_liq_rmapname = ./INPUT/access-om3-25km-rof-remap-weights.nc
-     rof_nx = 1440
-     rof_ny = 1152
+     rof2ocn_ice_rmapname = ./INPUT/access-om3-8km-rof-remap-weights.nc
+     rof2ocn_liq_rmapname = ./INPUT/access-om3-8km-rof-remap-weights.nc
+     rof_nx = 4320
+     rof_ny = 3672
      wav2ocn_smapname = unset
      wav_nx = 0
      wav_ny = 0
@@ -267,15 +267,15 @@ CLOCK_attributes::
      history_ymd = -999
      ice_cpl_dt = 99999 #not used
      lnd_cpl_dt = 99999 #not used
-     ocn_cpl_dt = 900 #ignored (coupling timestep set by nuopc.runseq) unless stop_option is nsteps
-     restart_n = 1
-     restart_option = nyears
+     ocn_cpl_dt = 450 #ignored (coupling timestep set by nuopc.runseq) unless stop_option is nsteps
+     restart_n = 2
+     restart_option = nmonths
      restart_ymd = -999
      rof_cpl_dt = 99999 #not used
      start_tod = 0
      start_ymd = 19000101
-     stop_n = 1
-     stop_option = nyears
+     stop_n = 2
+     stop_option = nmonths
      stop_tod = 0
      stop_ymd = -999
      tprof_n = -999
@@ -302,7 +302,7 @@ OCN_attributes::
 
 ROF_attributes::
      Verbosity = off
-     mesh_rof = ./INPUT/access-om3-25km-nomask-ESMFmesh.nc
+     mesh_rof = ./INPUT/access-om3-8km-nomask-ESMFmesh.nc
 ::
 
 MED_modelio::
@@ -356,13 +356,13 @@ OCN_modelio::
 ROF_modelio::
      diro = ./log
      logfile = rof.log
-     pio_async_interface = .false. 
-     pio_netcdf_format = nothing 
-     pio_numiotasks = 1 
-     pio_rearranger = 2 
-     pio_root = 1 
+     pio_async_interface = .false.
+     pio_netcdf_format = nothing
+     pio_numiotasks = 1
+     pio_rearranger = 2
+     pio_root = 1
      pio_stride = 1
-     pio_typename = netcdf4p 
+     pio_typename = netcdf4p
 ::
 
 DRV_modelio::

--- a/nuopc.runseq
+++ b/nuopc.runseq
@@ -1,5 +1,5 @@
 runSeq:: 
-@900
+@450
   MED med_phases_aofluxes_run
   MED med_phases_prep_ocn_accum
   MED med_phases_ocnalb_run

--- a/nuopc.runseq
+++ b/nuopc.runseq
@@ -1,5 +1,5 @@
 runSeq:: 
-@450
+@200
   MED med_phases_aofluxes_run
   MED med_phases_prep_ocn_accum
   MED med_phases_ocnalb_run

--- a/testing/checksum/historical-6hr-checksum.json
+++ b/testing/checksum/historical-6hr-checksum.json
@@ -1,101 +1,101 @@
 {
   "schema_version": "1-0-0",
   "output": {
-    "Salt": [
-      "4AFB3B7E51853863"
-    ],
     "Temp": [
-      "8006A9B653B4E52F"
+      "1C0A9900AD8E3D6D"
+    ],
+    "Salt": [
+      "175CCB02C9B4DA63"
     ],
     "h": [
-      "538A9F947368C09E"
+      "7677E982304129B"
     ],
     "u": [
-      "81BE896CE2C70F91"
+      "79896F3F743D746F"
     ],
-    "CAu": [
-      "A7DCBF4137F55707"
+    "v": [
+      "BD41606DDA4D5065"
     ],
     "First_direction": [
       "0"
     ],
     "ave_ssh": [
-      "EAA27D905DBA8C72"
+      "8BC1BFE24DB3340D"
     ],
     "frazil": [
-      "3485EF1EA81D55BD"
+      "250F5B65AB4D84A0"
     ],
     "p_surf_EOS": [
-      "C2D79276ED3BEDD3"
+      "223A2C4C1FCCD9F1"
     ],
     "sfc": [
-      "71E3D77B42F9CE42"
+      "30756072A1375797"
     ],
     "u2": [
-      "FC7B7C6B43B7B099"
-    ],
-    "v": [
-      "ED2CE338F5021842"
+      "660CADE92918CD89"
     ],
     "v2": [
-      "A972C4E41F88C91A"
+      "8FFC27B9DE5EBC25"
+    ],
+    "CAu": [
+      "8B86D2E81DD7A275"
     ],
     "CAv": [
-      "BF3C85139BF9EAD5"
-    ],
-    "DTBT": [
-      "4032D871A2F9800D"
-    ],
-    "MEKE": [
-      "19858C836D2AFEF0"
-    ],
-    "MEKE_Kh": [
-      "E0679698FD7C23BA"
-    ],
-    "MEKE_Ku": [
-      "34F51B57D8B18BE0"
-    ],
-    "age": [
-      "F372D3D5AA7C3D30"
+      "E31CBCB68353DA1F"
     ],
     "diffu": [
-      "A0EDA8ECF6ADEEA9"
+      "7237DE58C8533A7D"
     ],
     "diffv": [
-      "8214A99067DA2ADA"
+      "59E61B2323214F00"
+    ],
+    "DTBT": [
+      "4018F12B2940E895"
     ],
     "ubtav": [
-      "4DEDF2528443C481"
+      "CC3422F8E93B2D02"
     ],
     "vbtav": [
-      "80C3E4E41909EDDB"
+      "E1BAC88657E2BD30"
+    ],
+    "age": [
+      "F76CD42922489C0"
+    ],
+    "MEKE": [
+      "16B0D87AD7A8F975"
+    ],
+    "MEKE_Kh": [
+      "301DA531283B06DA"
+    ],
+    "MEKE_Ku": [
+      "CB3F3CE30F1FAE34"
     ],
     "Kd_shear": [
-      "B9B598E3E056B967"
+      "E8AD20EC686B3FD2"
     ],
     "Kv_shear": [
-      "2D9F41991BE7CD50"
+      "A989B6BE0DB21D0A"
     ],
     "Kv_shear_Bu": [
-      "39E9E4C0414EE9DE"
+      "CC05B834CCDE515C"
     ],
     "MLD": [
-      "54802E5BF428018A"
+      "4E3797665FFD156C"
     ],
     "MLD_MLE_filtered": [
-      "5265EF51C7E82092"
+      "670E0777838454B4"
     ],
     "MLD_MLE_filtered_slow": [
-      "35DF80C627CA1E3E"
+      "13AC5BB4445177C2"
     ],
     "MLE_Bflux": [
-      "FC1A031962007104"
+      "1CF26FFC4EDD6EB7"
     ],
     "SFC_BFLX": [
-      "E5D5950309CC5D77"
+      "FABDA2468D7F0BFE"
     ],
     "h_ML": [
-      "54802E5BF428018A"
+      "4E3797665FFD156C"
     ]
   }
 }


### PR DESCRIPTION
Second go at cherry-picking @angus-g's 8km ryf configuration ([653094a](https://github.com/angus-g/access-om3-configs/tree/653094aa342dfbae320af29411a9eb30d6545833)) onto our latest dev-MC_25km_jra_ryf branch (i.e. making it up to date -- [details](https://github.com/ACCESS-NRI/access-om3-configs/pull/1335#issuecomment-4468107268)). This is the third PR on this because we're looking to eventually merge this into our org and forks were deemed the [incorrect approach](https://forum.access-hive.org.au/t/cosima-twg-meeting-minutes-2026/5906/13?u=cbull), this new approach means we can use the org's CI etc.

Related:
 - https://github.com/ACCESS-NRI/access-om3-configs/issues/780
 - https://github.com/willaguiar/OM3-8km-tidal-tunning/issues/3#issue-3409780470
 - https://github.com/ACCESS-NRI/access-om3-configs/pull/1335
 - https://github.com/ACCESS-NRI/access-om3-configs/issues/1337