### PR TITLE
Update model-config-tests to 0.2.4

### DIFF
--- a/config/ci.json
+++ b/config/ci.json
@@ -22,7 +22,7 @@
         "release-MC_100km_jra_ryf": { },
         "release-MC_25km_jra_ryf": { },
         "release-.*": {
-            "model-config-tests-version": "0.2.2",
+            "model-config-tests-version": "0.2.4",
             "payu-version": "1.2.0"
         }
     },
@@ -34,7 +34,7 @@
             "markers": "repro and (not repro_restart)"
         },
         "release-.*": {
-            "model-config-tests-version": "0.2.2",
+            "model-config-tests-version": "0.2.4",
             "payu-version": "1.2.0"
         }
     },
@@ -44,7 +44,7 @@
         },
         "release-.*": {
             "markers": "access_om3 or config",
-            "model-config-tests-version": "0.2.2",
+            "model-config-tests-version": "0.2.4",
             "payu-version": "1.2.0"
         }
     },


### PR DESCRIPTION
Updates the version of `model-config-tests` from 0.2.2 to 0.2.4 in preparation for upcoming releases