### PR TITLE
Correction to remapping weights configuration in nuopc.runconfig

### DIFF
--- a/nuopc.runconfig
+++ b/nuopc.runconfig
@@ -249,8 +249,8 @@ MED_attributes::
      ocn_surface_flux_scheme = 0
      rof2lnd_map = unset
      rof2ocn_fmapname = unset
-     rof2ocn_ice_rmapname = ./INPUT/access-om3-panan4km-rof-remap-weights.nc
-     rof2ocn_liq_rmapname = unset
+     rof2ocn_ice_rmapname = unset
+     rof2ocn_liq_rmapname = ./INPUT/access-om3-panan4km-rof-remap-weights.nc
      rof2ocn_ice_spread = ./INPUT/access-om3-panan4km-rofi-climatology.nc
      rof_nx = 4320
      rof_ny = 1442

--- a/testing/checksum/historical-6hr-checksum.json
+++ b/testing/checksum/historical-6hr-checksum.json
@@ -2,91 +2,91 @@
   "schema_version": "1-0-0",
   "output": {
     "Temp": [
-      "A6432EF8826941AC"
+      "7971F61B47A29AB7"
     ],
     "Salt": [
-      "5385D2D387C1069A"
+      "49DC0822B73F70D6"
     ],
     "h": [
-      "237962ECF274C974"
+      "23C6D7F0B6B59295"
     ],
     "u": [
-      "521F97CE9EAE502C"
+      "C67A7B2BEAC44282"
     ],
     "First_direction": [
       "0"
     ],
     "ave_ssh": [
-      "719F7120DDB5B91F"
+      "721C32AFFC17E48D"
     ],
     "frazil": [
-      "FEFDE5D1088FF584"
+      "1DD01B450644B349"
     ],
     "p_surf_EOS": [
       "B3FBE733E2D136D5"
     ],
     "sfc": [
-      "586B9B41F4A0AFDF"
+      "D232CD65EA989456"
     ],
     "v": [
-      "429046F7614609A9"
+      "47749BFFAE9EFC94"
     ],
     "u2": [
-      "621079A0BB693681"
+      "198235672AD01030"
     ],
     "v2": [
-      "81D6EB513DCA9A0B"
+      "7F5D30918E673320"
     ],
     "CAu": [
-      "80826526CCD20585"
+      "15D5EB9E6FA611D5"
     ],
     "CAv": [
-      "79EC4A11DB5D5975"
+      "E63AB36A2276918E"
     ],
     "diffu": [
-      "4E5AC40B44F2A8DA"
+      "6C6692CD833CFE1F"
     ],
     "DTBT": [
-      "401A61564B42B5F3"
+      "401A61564B60D166"
     ],
     "diffv": [
-      "C129B4309AACAB5D"
+      "26C63E2F0BCEFF68"
     ],
     "ubtav": [
-      "E1220B3E8D21BE32"
+      "657FF197064E8F17"
     ],
     "vbtav": [
-      "4CD3AEF8135C2F4F"
+      "C85095E1EA2870E6"
     ],
     "age": [
-      "44759F6872149288"
+      "61E5D52701669C6A"
     ],
     "Kd_shear": [
-      "5B97D3B36D90393B"
+      "260A82AA96D44499"
     ],
     "Kv_shear": [
-      "5AFACC236931F69F"
+      "275D3302A47D99FB"
     ],
     "Kv_shear_Bu": [
-      "9D5015772B59BF7F"
+      "B8EFBA200E865D9C"
     ],
     "MLD": [
-      "F6F98D85473968A1"
+      "4E6D9AE333FEB24F"
     ],
     "MLD_MLE_filtered": [
-      "1974EFE9A55F5B07"
+      "664C68E6FA4FFCD0"
     ],
     "MLD_MLE_filtered_slow": [
-      "E592145D4E36EA4"
+      "6EE4637A847A549E"
     ],
     "MLE_Bflux": [
-      "48AC123043802DB8"
+      "1A024F4039209287"
     ],
     "SFC_BFLX": [
-      "E6344E45AC6DC840"
+      "ABBB88035F380167"
     ],
     "h_ML": [
-      "F6F98D85473968A1"
+      "4E6D9AE333FEB24F"
     ],
     "rx_normal": [
       "0"


### PR DESCRIPTION
<!-- use these prompts for changes to configuration branhces, skip them for main branch changes -->
**1. Summary**:

This fixes the configuration of runoff remapping weights. It was incorrectly being used for iceberg field, they are needed to liquid runoff fields

**2. Issues Addressed:**
<!-- Add links to github issue(s) this is related to -->
- Correction related to #404



**4. Ad-hoc Testing**

What ad-hoc testing was done? How are you convinced this change is correct (plots are good)?

**5. CI Testing**
<!-- Has the CI-testing been run? -->
- [x] `!test repro` or `!test repro commit ` has been run

**6. Reproducibility**

Is this reproducible with the previous commit? (If not, why not?)
- [ ] Yes
- [x] No


