### PR TITLE
Update payu version in ci.json

### DIFF
--- a/config/ci.json
+++ b/config/ci.json
@@ -23,7 +23,7 @@
         "release-MC_25km_jra_ryf": { },
         "release-.*": {
             "model-config-tests-version": "0.2.4",
-            "payu-version": "1.2.0"
+            "payu-version": "1.3.2"
         }
     },
     "reproducibility": {
@@ -35,7 +35,7 @@
         },
         "release-.*": {
             "model-config-tests-version": "0.2.4",
-            "payu-version": "1.2.0"
+            "payu-version": "1.3.2"
         }
     },
     "qa": {
@@ -45,7 +45,7 @@
         "release-.*": {
             "markers": "access_om3 or config",
             "model-config-tests-version": "0.2.4",
-            "payu-version": "1.2.0"
+            "payu-version": "1.3.2"
         }
     },
     "default": {


### PR DESCRIPTION
Needed because some of our configs have:

```
payu_minimum_version: 1.3.2
```