### PR TITLE
Increase MOM6 timesteps: DT=3600, DT_THERM=7200, DTBT=-0.9

### DIFF
--- a/MOM_input
+++ b/MOM_input
@@ -33,15 +33,20 @@ USE_CONTEMP_ABSSAL = True       !   [Boolean] default = False
 USE_REGRIDDING = True           !   [Boolean] default = False
                                 ! If True, use the ALE algorithm (regridding/remapping). If False, use the
                                 ! layered isopycnal algorithm.
-DT = 1800.0                     !   [s]
+DT = 3600.0                     !   [s]
                                 ! The (baroclinic) dynamics time step.  The time-step that is actually used will
                                 ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
                                 ! or the coupling timestep in coupled mode.)
-DT_THERM = 3600.0               !   [s] default = 1800.0
+DT_THERM = 7200.0               !   [s] default = 1800.0
                                 ! The thermodynamic time step. Ideally DT_THERM should be an integer multiple of
                                 ! DT and of DT_TRACER_ADVECT and less than the forcing or coupling time-step.
                                 ! However, if THERMO_SPANS_COUPLING is true, DT_THERM can be an integer multiple
                                 ! of the coupling timestep. By default DT_THERM is set to DT.
+THERMO_SPANS_COUPLING = True    !   [Boolean] default = False
+                                ! If true, the MOM6 dynamic and thermodynamic time stepping is done at the driver
+                                ! level with a call to a dynamics-only integration followed by a call to a
+                                ! thermodynamics-only integration. Required here because DT_THERM (7200 s) is an
+                                ! integer multiple of the coupling timestep (3600 s), not just of DT.
 THICKNESSDIFFUSE = True         !   [Boolean] default = False
                                 ! If true, isopycnal surfaces are diffused with a Laplacian coefficient of KHTH.
 THICKNESSDIFFUSE_FIRST = True   !   [Boolean] default = False
@@ -506,7 +511,7 @@ BEBT = 0.2                      !   [nondim] default = 0.1
                                 ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
                                 ! (for a backward Euler treatment). In practice, BEBT must be greater than about
                                 ! 0.05.
-DTBT = -0.95                    !   [s or nondim] default = -0.98
+DTBT = -0.9                     !   [s or nondim] default = -0.98
                                 ! The barotropic time step, in s. DTBT is only used with the split explicit time
                                 ! stepping. To set the time step automatically based the maximum stable value
                                 ! use 0, or a negative value gives the fraction of the stable value. Setting

--- a/docs/MOM_parameter_doc.all
+++ b/docs/MOM_parameter_doc.all
@@ -68,27 +68,27 @@ ENABLE_BUGS_BY_DEFAULT = True   !   [Boolean] default = True
                                 ! will no longer be used to set their default.  Setting this to false means that
                                 ! bugs are only used if they are actively selected, but it also means that
                                 ! answers may change when code is updated due to newly found bugs.
-DT = 1800.0                     !   [s]
+DT = 3600.0                     !   [s]
                                 ! The (baroclinic) dynamics time step.  The time-step that is actually used will
                                 ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
                                 ! or the coupling timestep in coupled mode.)
-DT_THERM = 3600.0               !   [s] default = 1800.0
+DT_THERM = 7200.0               !   [s] default = 3600.0
                                 ! The thermodynamic time step. Ideally DT_THERM should be an integer multiple of
                                 ! DT and of DT_TRACER_ADVECT and less than the forcing or coupling time-step.
                                 ! However, if THERMO_SPANS_COUPLING is true, DT_THERM can be an integer multiple
                                 ! of the coupling timestep. By default DT_THERM is set to DT.
-THERMO_SPANS_COUPLING = False   !   [Boolean] default = False
+THERMO_SPANS_COUPLING = True    !   [Boolean] default = False
                                 ! If true, the MOM will take thermodynamic timesteps that can be longer than the
                                 ! coupling timestep. The actual thermodynamic timestep that is used in this case
                                 ! is the largest integer multiple of the coupling timestep that is less than or
                                 ! equal to DT_THERM.
-DT_TRACER_ADVECT = 3600.0       !   [s] default = 3600.0
+DT_TRACER_ADVECT = 7200.0       !   [s] default = 7200.0
                                 ! The tracer advection time step. Ideally DT_TRACER_ADVECT should be an integer
                                 ! multiple of DT, less than DT_THERM, and less than the forcing or coupling
                                 ! time-step. However, if TRADV_SPANS_COUPLING is true, DT_TRACER_ADVECT can be
                                 ! longer than the coupling timestep. By default DT_TRACER_ADVECT is set to
                                 ! DT_THERM.
-TRADV_SPANS_COUPLING = False    !   [Boolean] default = False
+TRADV_SPANS_COUPLING = True     !   [Boolean] default = True
                                 ! If true, the MOM will take tracer advection timesteps that can be longer than
                                 ! the coupling timestep. The actual tracer advection timestep that is used in
                                 ! this case is the largest integer multiple of the coupling timestep that is
@@ -117,7 +117,7 @@ HFREEZE = 10.0                  !   [m] default = -1.0
 INTERPOLATE_P_SURF = False      !   [Boolean] default = False
                                 ! If true, linearly interpolate the surface pressure over the coupling time
                                 ! step, using the specified value at the end of the step.
-DTBT_RESET_PERIOD = 0.0         !   [s] default = 3600.0
+DTBT_RESET_PERIOD = 0.0         !   [s] default = 7200.0
                                 ! The period between recalculations of DTBT (if DTBT <= 0). If DTBT_RESET_PERIOD
                                 ! is negative, DTBT is set based only on information available at
                                 ! initialization.  If 0, DTBT will be set every dynamics time step. The default
@@ -1704,7 +1704,7 @@ BEBT = 0.2                      !   [nondim] default = 0.1
                                 ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
                                 ! (for a backward Euler treatment). In practice, BEBT must be greater than about
                                 ! 0.05.
-DTBT = -0.95                    !   [s or nondim] default = -0.98
+DTBT = -0.9                     !   [s or nondim] default = -0.98
                                 ! The barotropic time step, in s. DTBT is only used with the split explicit time
                                 ! stepping. To set the time step automatically based the maximum stable value
                                 ! use 0, or a negative value gives the fraction of the stable value. Setting

--- a/docs/MOM_parameter_doc.short
+++ b/docs/MOM_parameter_doc.short
@@ -9,15 +9,20 @@ USE_CONTEMP_ABSSAL = True       !   [Boolean] default = False
 USE_REGRIDDING = True           !   [Boolean] default = False
                                 ! If True, use the ALE algorithm (regridding/remapping). If False, use the
                                 ! layered isopycnal algorithm.
-DT = 1800.0                     !   [s]
+DT = 3600.0                     !   [s]
                                 ! The (baroclinic) dynamics time step.  The time-step that is actually used will
                                 ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
                                 ! or the coupling timestep in coupled mode.)
-DT_THERM = 3600.0               !   [s] default = 1800.0
+DT_THERM = 7200.0               !   [s] default = 3600.0
                                 ! The thermodynamic time step. Ideally DT_THERM should be an integer multiple of
                                 ! DT and of DT_TRACER_ADVECT and less than the forcing or coupling time-step.
                                 ! However, if THERMO_SPANS_COUPLING is true, DT_THERM can be an integer multiple
                                 ! of the coupling timestep. By default DT_THERM is set to DT.
+THERMO_SPANS_COUPLING = True    !   [Boolean] default = False
+                                ! If true, the MOM will take thermodynamic timesteps that can be longer than the
+                                ! coupling timestep. The actual thermodynamic timestep that is used in this case
+                                ! is the largest integer multiple of the coupling timestep that is less than or
+                                ! equal to DT_THERM.
 THICKNESSDIFFUSE = True         !   [Boolean] default = False
                                 ! If true, isopycnal surfaces are diffused with a Laplacian coefficient of KHTH.
 THICKNESSDIFFUSE_FIRST = True   !   [Boolean] default = False
@@ -28,7 +33,7 @@ HFREEZE = 10.0                  !   [m] default = -1.0
                                 ! melt potential is computed will be min(HFREEZE, OBLD), where OBLD is the
                                 ! boundary layer depth. If HFREEZE <= 0 (default), melt potential will not be
                                 ! computed.
-DTBT_RESET_PERIOD = 0.0         !   [s] default = 3600.0
+DTBT_RESET_PERIOD = 0.0         !   [s] default = 7200.0
                                 ! The period between recalculations of DTBT (if DTBT <= 0). If DTBT_RESET_PERIOD
                                 ! is negative, DTBT is set based only on information available at
                                 ! initialization.  If 0, DTBT will be set every dynamics time step. The default
@@ -482,7 +487,7 @@ BEBT = 0.2                      !   [nondim] default = 0.1
                                 ! from 0 (for a forward-backward treatment of nonrotating gravity waves) to 1
                                 ! (for a backward Euler treatment). In practice, BEBT must be greater than about
                                 ! 0.05.
-DTBT = -0.95                    !   [s or nondim] default = -0.98
+DTBT = -0.9                     !   [s or nondim] default = -0.98
                                 ! The barotropic time step, in s. DTBT is only used with the split explicit time
                                 ! stepping. To set the time step automatically based the maximum stable value
                                 ! use 0, or a negative value gives the fraction of the stable value. Setting
@@ -778,3 +783,5 @@ USE_RIGID_SEA_ICE = True        !   [Boolean] default = False
 SEA_ICE_RIGID_MASS = 100.0      !   [kg m-2] default = 1000.0
                                 ! The mass of sea-ice per unit area at which the sea-ice starts to exhibit
                                 ! rigidity
+
+! === module MOM_restart ===

--- a/testing/checksum/historical-6hr-checksum.json
+++ b/testing/checksum/historical-6hr-checksum.json
@@ -2,100 +2,100 @@
   "schema_version": "1-0-0",
   "output": {
     "CAu": [
-      "62C09A2969EEA135"
+      "2299837131A591CF"
     ],
     "CAv": [
-      "1C5A986C28B4A8AC"
+      "CCFBBDEAD555466"
     ],
     "DTBT": [
-      "4054BD37F85DBE7B"
+      "4053A5C9A68F8B34"
     ],
     "First_direction": [
       "0"
     ],
     "Kd_shear": [
-      "91769D58752E91A3"
+      "8865F3267ACE4FDD"
     ],
     "Kv_shear": [
-      "5F4C58B95327B591"
+      "56C8C4774C4C836E"
     ],
     "Kv_shear_Bu": [
-      "C3CC0F02599C6F5"
+      "3724F2B2DEB69230"
     ],
     "MEKE": [
-      "9DC91D8128C1CA51"
+      "EDE902B4469CE849"
     ],
     "MEKE_Kh": [
-      "B765B37571EDFAB1"
+      "A2FD0B3616C94EE4"
     ],
     "MEKE_Ku": [
-      "83E2F078F6128A13"
+      "6FB6FE7720EE17E1"
     ],
     "MLD": [
-      "99FFA440C61180D8"
+      "23D25B5501BBBC18"
     ],
     "MLD_MLE_filtered": [
-      "DD653A487B2512CA"
+      "926B81AE4AD01647"
     ],
     "MLD_MLE_filtered_slow": [
-      "899FD9B1FD1A14"
+      "A2BC782A422E5281"
     ],
     "MLE_Bflux": [
-      "2F40BD42FD2FF13E"
+      "7DEFDF06E824BF39"
     ],
     "SFC_BFLX": [
-      "F8A6F818465B6766"
+      "DC40A1857CC7CDFD"
     ],
     "Salt": [
-      "BF941F61A0ADDEC2"
+      "E926A55D44EC6F3A"
     ],
     "Temp": [
-      "78D5A7300563A72C"
+      "3C4287CC9D7089DD"
     ],
     "age": [
-      "E194A92EF995AF9E"
+      "8A61F3ED757D9850"
     ],
     "ave_ssh": [
-      "86C0641A985F0A83"
+      "871AC8422D1A92D0"
     ],
     "diffu": [
-      "F6F470A1AE595363"
+      "7C2CFD6BD42E639F"
     ],
     "diffv": [
-      "2DA7DEABB27AAB71"
+      "8711C81E1A0F5C04"
     ],
     "frazil": [
-      "663AC1A571B8E3FD"
+      "AE2C0BEB0C1838C"
     ],
     "h": [
-      "B0C5D234720AAEC5"
+      "B0DF395B930D91EA"
     ],
     "h_ML": [
-      "99FFA440C61180D8"
+      "23D25B5501BBBC18"
     ],
     "p_surf_EOS": [
       "317762F5F33EBB32"
     ],
     "sfc": [
-      "7E2359AEAD41A1DE"
+      "F9F334282EBECF2B"
     ],
     "u": [
-      "AE69DA84459F4C57"
+      "B78EAEFCB13F2863"
     ],
     "u2": [
-      "520330E5AAC19C7"
+      "AA4783F20629FCE2"
     ],
     "ubtav": [
-      "6643BDDA6A08CDAA"
+      "214C6282CBDE57B"
     ],
     "v": [
-      "7D8B00E573E0DB6"
+      "80D892E220004C3A"
     ],
     "v2": [
-      "4673B816D6F7BD6E"
+      "A0B6303DB449589"
     ],
     "vbtav": [
-      "83FC33AD9EF2E475"
+      "46A10F1E9CA3C7AD"
     ]
   }
 }


### PR DESCRIPTION
<!-- use these prompts for changes to configuration branhces, skip them for main branch changes -->
**1. Summary**:

Aligns `DT_THERM`, `THERMO_SPANS_COUPLING`, and `DTBT` with the values used in [`dev-MC_25km_jra_iaf`'s ](https://github.com/ACCESS-NRI/access-om3-configs/blob/dev-MC_25km_jra_iaf/MOM_input) `MOM_input`. `DT` is increased to match the coupling time step.

| Param | Before | After | vs `dev-MC_25km_jra_iaf` |
|---|---|---|---|
| `DT` | 1800 | **3600** | 900 (resolution dependent) |
| `DT_THERM` | 3600 | **7200** | matches |
| `THERMO_SPANS_COUPLING` | (unset) | **True** | matches (required since DT_THERM > coupling step) |
| `DTBT` | -0.95 | **-0.9** | matches |

Stable through  multi-year runs, no crashes, NaNs, or truncation issues. Walltime reduced ~46% (DT alone) to ~52% (full stack) vs the current config.

**2. Issues Addressed:**
https://github.com/ACCESS-NRI/access-om3-configs/issues/1505

**5. CI Testing**
<!-- Has the CI-testing been run? -->
- [x] `!test repro` or `!test repro commit ` has been run

**6. Reproducibility**

Is this reproducible with the previous commit? (If not, why not?)
- [ ] Yes
- [x] No (Time step changes)

**8. Formatting**
<!-- Are changes to MOM_input in the same order as docs/MOM_parameter_docs.short? -->

Changes to MOM_input have been copied from model output in docs/MOM_parameter_docs.short?
- [x] Yes
- [ ] N/A

**9. Merge Strategy**
<!-- What is the planned merge strategy (Merge commit, Rebase and merge, or squash) ?
If not squash, link to the related issue in the commit descriptions -->

- [ ] Merge commit
- [ ] Rebase and merge
- [x] Squash
