### PR TITLE
GCC testing for 25km

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -18,8 +18,9 @@ sync:
 modules:
     use:
         - /g/data/vk83/modules
+        - /g/data/vk83/prerelease/modules
     load:
-        - access-om3/2026.05.002
+        - access-om3/pr253-2 # uses gcc for entire toolchain
         - model-tools/mppnccombine-fast/2025.07.000
 
 queue: normalsr
@@ -56,7 +57,7 @@ metadata:
     enable: true
 manifest:
   reproduce:
-    exe: True
+    exe: False
     input: True
 
 mpi:


### PR DESCRIPTION
This PR is to get `access-om3` working with `gcc`. The original intention was to be able to get code coverage for GPU porting. This also serves as a meaningful step toward enabling om3 for other users who may not prefer gcc.