### PR TITLE
ePBL parameters from Li (2019)

### DIFF
--- a/MOM_input
+++ b/MOM_input
@@ -705,9 +705,8 @@ MIX_LEN_EXPONENT = 1.0          !   [nondim] default = 2.0
                                 ! The exponent applied to the ratio of the distance to the MLD and the MLD depth
                                 ! which determines the shape of the mixing length. This is only used if
                                 ! USE_MLD_ITERATION is True.
-USE_LA_LI2016 = True            !   [Boolean] default = False
-                                ! A logical to use the Li et al. 2016 (submitted) formula to determine the
-                                ! Langmuir number.
+EPBL_LT = True                  !   [nondim] default = False
+                                ! A logical to use a LT parameterization.
 EPBL_LANGMUIR_SCHEME = "ADDITIVE" ! default = "NONE"
                                 ! EPBL_LANGMUIR_SCHEME selects the method for including Langmuir turbulence.
                                 ! Valid values are:
@@ -716,17 +715,17 @@ EPBL_LANGMUIR_SCHEME = "ADDITIVE" ! default = "NONE"
                                 !      turbulence
                                 !    ADDITIVE - Add a Langmuir turbulence contribution to mstar to other
                                 !      contributions
-LT_ENHANCE_COEF = 0.044         !   [nondim] default = 0.447
+LT_ENHANCE_COEF = 0.105         !   [nondim] default = 0.447
                                 ! Coefficient for Langmuir enhancement of mstar
-LT_ENHANCE_EXP = -1.5           !   [nondim] default = -1.33
+LT_ENHANCE_EXP = -1.0           !   [nondim] default = -1.33
                                 ! Exponent for Langmuir enhancement of mstar
 LT_MOD_LAC1 = 0.0               !   [nondim] default = -0.87
                                 ! Coefficient for modification of Langmuir number due to MLD approaching Ekman
                                 ! depth.
-LT_MOD_LAC4 = 0.0               !   [nondim] default = 0.95
+LT_MOD_LAC4 = 0.8               !   [nondim] default = 0.95
                                 ! Coefficient for modification of Langmuir number due to ratio of Ekman to
                                 ! stable Obukhov depth.
-LT_MOD_LAC5 = 0.22              !   [nondim] default = 0.95
+LT_MOD_LAC5 = 0.8               !   [nondim] default = 0.95
                                 ! Coefficient for modification of Langmuir number due to ratio of Ekman to
                                 ! unstable Obukhov depth.
 

--- a/docs/MOM_parameter_doc.all
+++ b/docs/MOM_parameter_doc.all
@@ -2328,9 +2328,11 @@ EPBL_BBL_EFFIC = 0.0            !   [nondim] default = 0.0
 EPBL_BBL_TIDAL_EFFIC = 0.0      !   [nondim] default = 0.0
                                 ! The efficiency of bottom boundary layer mixing via ePBL driven by the bottom
                                 ! drag dissipation of tides, as provided in fluxes%BBL_tidal_dis.
-USE_LA_LI2016 = True            !   [Boolean] default = False
+USE_LA_LI2016 = False           !   [Boolean] default = False
                                 ! A logical to use the Li et al. 2016 (submitted) formula to determine the
                                 ! Langmuir number.
+EPBL_LT = True                  !   [Boolean] default = False
+                                ! A logical to use a LT parameterization.
 EPBL_LANGMUIR_SCHEME = "ADDITIVE" ! default = "NONE"
                                 ! EPBL_LANGMUIR_SCHEME selects the method for including Langmuir turbulence.
                                 ! Valid values are:
@@ -2339,9 +2341,9 @@ EPBL_LANGMUIR_SCHEME = "ADDITIVE" ! default = "NONE"
                                 !      turbulence
                                 !    ADDITIVE - Add a Langmuir turbulence contribution to mstar to other
                                 !      contributions
-LT_ENHANCE_COEF = 0.044         !   [nondim] default = 0.447
+LT_ENHANCE_COEF = 0.105         !   [nondim] default = 0.447
                                 ! Coefficient for Langmuir enhancement of mstar
-LT_ENHANCE_EXP = -1.5           !   [nondim] default = -1.33
+LT_ENHANCE_EXP = -1.0           !   [nondim] default = -1.33
                                 ! Exponent for Langmuir enhancement of mstar
 LT_MOD_LAC1 = 0.0               !   [nondim] default = -0.87
                                 ! Coefficient for modification of Langmuir number due to MLD approaching Ekman
@@ -2352,10 +2354,10 @@ LT_MOD_LAC2 = 0.0               !   [nondim] default = 0.0
 LT_MOD_LAC3 = 0.0               !   [nondim] default = 0.0
                                 ! Coefficient for modification of Langmuir number due to MLD approaching
                                 ! unstable Obukhov depth.
-LT_MOD_LAC4 = 0.0               !   [nondim] default = 0.95
+LT_MOD_LAC4 = 0.8               !   [nondim] default = 0.95
                                 ! Coefficient for modification of Langmuir number due to ratio of Ekman to
                                 ! stable Obukhov depth.
-LT_MOD_LAC5 = 0.22              !   [nondim] default = 0.95
+LT_MOD_LAC5 = 0.8               !   [nondim] default = 0.95
                                 ! Coefficient for modification of Langmuir number due to ratio of Ekman to
                                 ! unstable Obukhov depth.
 EPBL_EQD_DIFFUSIVITY_SHAPE = False !   [nondim] default = False
@@ -2685,31 +2687,6 @@ LA_DEPTH_RATIO = 0.04           !   [nondim] default = 0.04
 LA_DEPTH_MIN = 0.1              !   [m] default = 0.1
                                 ! The minimum depth over which to average the Stokes drift in the Langmuir
                                 ! number calculation.
-VISCOSITY_AIR = 1.0E-06         !   [m2 s-1] default = 1.0E-06
-                                ! A typical viscosity of air at sea level, as used in wave calculations
-VON_KARMAN_WAVES = 0.4          !   [nondim] default = 0.4
-                                ! The value the von Karman constant as used for surface wave calculations.
-RHO_AIR = 1.225                 !   [kg m-3] default = 1.225
-                                ! A typical density of air at sea level, as used in wave calculations
-RHO_SFC_WAVES = 1035.0          !   [kg m-3] default = 1035.0
-                                ! A typical surface density of seawater, as used in wave calculations in
-                                ! comparison with the density of air.  The default is RHO_0.
-WAVE_HEIGHT_SCALE_FACTOR = 0.0246 !   [s2 m-1] default = 0.0246
-                                ! A factor relating the square of the 10 m wind speed to the significant wave
-                                ! height, with a default value based on the Pierson-Moskowitz spectrum.
-CHARNOCK_MIN = 0.028            !   [nondim] default = 0.028
-                                ! The minimum value of the Charnock coefficient, which relates the square of the
-                                ! air friction velocity divided by the gravitational acceleration to the wave
-                                ! roughness length.
-CHARNOCK_SLOPE_U10 = 0.0017     !   [s m-1] default = 0.0017
-                                ! The partial derivative of the Charnock coefficient with the 10 m wind speed.
-                                ! Note that in eq. 13 of the Edson et al. 2013 describing the COARE 3.5 bulk
-                                ! flux algorithm, this slope is given as 0.017.  However, 0.0017 reproduces the
-                                ! curve in their figure 6, so that is the default value used in MOM6.
-CHARNOCK_0_WIND_INTERCEPT = -0.005 !   [nondim] default = -0.005
-                                ! The intercept of the fit for the Charnock coefficient in the limit of no wind.
-                                ! Note that this can be negative because CHARNOCK_MIN will keep the final value
-                                ! for the Charnock coefficient from being from being negative.
 LAGRANGIAN_MIXING = False       !   [Boolean] default = False
                                 ! Flag to use Lagrangian Mixing of momentum
 STOKES_MIXING = False           !   [Boolean] default = False

--- a/docs/MOM_parameter_doc.short
+++ b/docs/MOM_parameter_doc.short
@@ -681,9 +681,8 @@ MIX_LEN_EXPONENT = 1.0          !   [nondim] default = 2.0
                                 ! The exponent applied to the ratio of the distance to the MLD and the MLD depth
                                 ! which determines the shape of the mixing length. This is only used if
                                 ! USE_MLD_ITERATION is True.
-USE_LA_LI2016 = True            !   [Boolean] default = False
-                                ! A logical to use the Li et al. 2016 (submitted) formula to determine the
-                                ! Langmuir number.
+EPBL_LT = True                  !   [Boolean] default = False
+                                ! A logical to use a LT parameterization.
 EPBL_LANGMUIR_SCHEME = "ADDITIVE" ! default = "NONE"
                                 ! EPBL_LANGMUIR_SCHEME selects the method for including Langmuir turbulence.
                                 ! Valid values are:
@@ -692,17 +691,17 @@ EPBL_LANGMUIR_SCHEME = "ADDITIVE" ! default = "NONE"
                                 !      turbulence
                                 !    ADDITIVE - Add a Langmuir turbulence contribution to mstar to other
                                 !      contributions
-LT_ENHANCE_COEF = 0.044         !   [nondim] default = 0.447
+LT_ENHANCE_COEF = 0.105         !   [nondim] default = 0.447
                                 ! Coefficient for Langmuir enhancement of mstar
-LT_ENHANCE_EXP = -1.5           !   [nondim] default = -1.33
+LT_ENHANCE_EXP = -1.0           !   [nondim] default = -1.33
                                 ! Exponent for Langmuir enhancement of mstar
 LT_MOD_LAC1 = 0.0               !   [nondim] default = -0.87
                                 ! Coefficient for modification of Langmuir number due to MLD approaching Ekman
                                 ! depth.
-LT_MOD_LAC4 = 0.0               !   [nondim] default = 0.95
+LT_MOD_LAC4 = 0.8               !   [nondim] default = 0.95
                                 ! Coefficient for modification of Langmuir number due to ratio of Ekman to
                                 ! stable Obukhov depth.
-LT_MOD_LAC5 = 0.22              !   [nondim] default = 0.95
+LT_MOD_LAC5 = 0.8               !   [nondim] default = 0.95
                                 ! Coefficient for modification of Langmuir number due to ratio of Ekman to
                                 ! unstable Obukhov depth.
 

--- a/testing/checksum/historical-6hr-checksum.json
+++ b/testing/checksum/historical-6hr-checksum.json
@@ -2,100 +2,100 @@
   "schema_version": "1-0-0",
   "output": {
     "CAu": [
-      "E42F000B7E0E69BE"
+      "3484AB20CFF41CC1"
     ],
     "CAv": [
-      "9DBFC9417172D7BF"
+      "35745713C6C668A3"
     ],
     "DTBT": [
-      "4053A5C9A461AF6F"
+      "4053A5C9A5BCFDF9"
     ],
     "First_direction": [
       "0"
     ],
     "Kd_shear": [
-      "8F7EEF474302594B"
+      "E71BB97FE96DE8CC"
     ],
     "Kv_shear": [
-      "8C5336B3C41C9ED4"
+      "2866D8B628AA73E1"
     ],
     "Kv_shear_Bu": [
-      "E96224C35FEBACC6"
+      "762E3DB5F0CD6D9B"
     ],
     "MEKE": [
-      "F4A5803629399DFE"
+      "F282C30DD857D8C1"
     ],
     "MEKE_Kh": [
-      "A1A6A55EC0099551"
+      "ADBEC5EAD0D2743B"
     ],
     "MEKE_Ku": [
-      "6CD054D48A3C37AD"
+      "7A11342B049FDDAF"
     ],
     "MLD": [
-      "2EA4F43195D5FC21"
+      "E06A01BBAA12DEEA"
     ],
     "MLD_MLE_filtered": [
-      "33F3C348397EC685"
+      "95BC79D120A803E0"
     ],
     "MLD_MLE_filtered_slow": [
-      "40F3185EF3805DD8"
+      "A7C78F12555AF6D6"
     ],
     "MLE_Bflux": [
-      "EEFB2A98B22B512A"
+      "ADB33A153F678FD2"
     ],
     "SFC_BFLX": [
-      "4B732541DE7EEC5"
+      "ACB2E2CF04EC3EFD"
     ],
     "Salt": [
-      "D8D0D988E2FC5618"
+      "E4F179B70E0EA4C2"
     ],
     "Temp": [
-      "9DBF476A288B5EFB"
+      "A09A652495546C12"
     ],
     "age": [
-      "3BABCA062BA81205"
+      "B669C082BB23923F"
     ],
     "ave_ssh": [
-      "E8C28FDC332BD865"
+      "E8BC2C6EE752D2A5"
     ],
     "diffu": [
-      "99836C719C5BB139"
+      "D684702C45B485F8"
     ],
     "diffv": [
-      "E2724BE90C59E08B"
+      "A1A7A94171FC8EA4"
     ],
     "frazil": [
-      "BE7B99938B6074CA"
+      "B905D36AFD5A6B0D"
     ],
     "h": [
-      "1376D68DDEF0C4C4"
+      "135C0748FDA3FE01"
     ],
     "h_ML": [
-      "2EA4F43195D5FC21"
+      "E06A01BBAA12DEEA"
     ],
     "p_surf_EOS": [
       "317762F5F33EBB32"
     ],
     "sfc": [
-      "5B8377C0FB1A9F71"
+      "DB9D5BDA1A3141C7"
     ],
     "u": [
-      "D82AC411956B5AC9"
+      "86FD9D592DE68C1A"
     ],
     "u2": [
-      "DFCFB8B4A75B8846"
+      "6C9C0B4FA4D27392"
     ],
     "ubtav": [
-      "7B9B65CE874098B6"
+      "119A5887F083420"
     ],
     "v": [
-      "E3CE2EA5A6DBA051"
+      "76BF098F8D9BFD"
     ],
     "v2": [
-      "99BD0BE2679CB8AC"
+      "232804787CB9216A"
     ],
     "vbtav": [
-      "C2DAAC482144643B"
+      "44E4B8D77632A4FC"
     ]
   }
 }


### PR DESCRIPTION
<!-- use these prompts for changes to configuration branches, skip them for main branch changes -->
**1. Summary**:

ePBL Langmuir turbulence parameters are now taken from Li, Reichl, et al. JAMES (2019) due to their improved performance https://github.com/ACCESS-NRI/access-om3-configs/issues/950

**2. Issues Addressed:**
<!-- Add links to github issue(s) this is related to -->
- https://github.com/ACCESS-NRI/access-om3-configs/issues/950

**3. Dependencies (e.g. on payu, model or om3-scripts)**

N/A
<!-- Describe and link to the related changes to dependencies -->

**4. Ad-hoc Testing**

Testing of these parameters with ERA5 forcing is promising with improved MLDs, SIE, SSTs https://github.com/ACCESS-NRI/access-om3-configs/issues/950. Only a short run with this branch was completed to test stability (since it is still using JRA55-do).

**5. CI Testing**
<!-- Has the CI-testing been run? -->
- [x] `!test repro` or `!test repro commit ` has been run

**6. Reproducibility**

Is this reproducible with the previous commit? (If not, why not?)
- [ ] Yes
- [x] No

Scientific changes.

**7. Documentation**
<!--Does this impact documentation? Has the wiki been updated? Have the `docs/MOM_*` files been updated ?-->

The docs folder has been updated with output from running the model?
- [ ] Yes
- [x] N/A

A PR has been created for updating the documentation?
- [ ] Yes: <!--link-->
- [x] N/A

**8. Formatting**
<!-- Are changes to MOM_input in the same order as docs/MOM_parameter_docs.short? -->

Changes to MOM_input have been copied from model output in docs/MOM_parameter_docs.short?
- [x] Yes
- [ ] N/A

**9. Merge Strategy**
<!-- What is the planned merge strategy (Merge commit, Rebase and merge, or squash) ?
If not squash, link to the related issue in the commit descriptions -->

- [ ] Merge commit
- [ ] Rebase and merge
- [x] Squash
