### PR TITLE
Set CICE wave spectrum type to constant

### DIFF
--- a/ice_in
+++ b/ice_in
@@ -67,7 +67,7 @@
   tfrz_option = "linear_salt"
   update_ocn_f = .true.
   ustar_min = 0.0005
-  wave_spec_type = "random"
+  wave_spec_type = "constant"
   /
 &domain_nml
   block_size_x = 15


### PR DESCRIPTION
<!-- use these prompts for changes to configuration branhces, skip them for main branch changes -->
**1. Summary**:

This change sets `wave_spec_type = "constant"` in CICE as a temporary workaround for the restart reproducibility failure in MCW configurations ([#949](https://github.com/ACCESS-NRI/access-om3-configs/issues/949)). It should be superseded once Noah’s ICDR method is implemented in Icepack.

**2. Issues Addressed:**

- https://github.com/ACCESS-NRI/access-om3-configs/issues/949

**5. CI Testing**
<!-- Has the CI-testing been run? -->
- [x] `!test repro` or `!test repro commit ` has been run

**6. Reproducibility**

Is this reproducible with the previous commit? (If not, why not?)
- [ ] Yes
- [x] No - Science changes

**7. Documentation**
<!--Does this impact documentation? Has the wiki been updated? Have the `docs/MOM_*` files been updated ?-->

The docs folder has been updated with output from running the model?
- [ ] Yes
- [x] N/A

A PR has been created for updating the documentation?
- [ ] Yes: <!--link-->
- [x] N/A

**8. Formatting**
<!-- Are changes to MOM_input in the same order as docs/MOM_parameter_docs.short? -->

Changes to MOM_input have been copied from model output in docs/MOM_parameter_docs.short?
- [ ] Yes
- [x] N/A

**9. Merge Strategy**
<!-- What is the planned merge strategy (Merge commit, Rebase and merge, or squash) ?
If not squash, link to the related issue in the commit descriptions -->

- [x] Merge commit
- [ ] Rebase and merge
- [ ] Squash