### PR TITLE
Update build to 2026.05.003

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -19,7 +19,7 @@ modules:
     use:
         - /g/data/vk83/modules
     load:
-        - access-om3/2026.05.002
+        - access-om3/2026.05.003
 
 queue: normalsr
 ncpus: 208

--- a/manifests/exe.yaml
+++ b/manifests/exe.yaml
@@ -2,7 +2,7 @@ format: yamanifest
 version: 1.0
 ---
 work/access-om3-MOM6-CICE6-WW3:
-  fullpath: /g/data/vk83/apps/spack/1.1/release/linux-x86_64_v4/access3-2026.03.002-7t6n2ft5xzps2ftbhvsj74zya7n4amal/bin/access-om3-MOM6-CICE6-WW3
+  fullpath: /g/data/vk83/apps/spack/1.1/release/linux-x86_64_v4/access3-2026.03.002-arkg6foly5p2q3hj7asfpdibuv5nq4pn/bin/access-om3-MOM6-CICE6-WW3
   hashes:
-    binhash: 68bf920b09dd697ec67ea716aec4818d
-    md5: 6152c65bfcadb12467235008ccdeda76
+    binhash: 03907bc718134a32d3f05692bd1254a8
+    md5: 6a858d16a4bcb7362b48336701f1163e

--- a/testing/checksum/historical-6hr-checksum.json
+++ b/testing/checksum/historical-6hr-checksum.json
@@ -2,10 +2,10 @@
   "schema_version": "1-0-0",
   "output": {
     "CAu": [
-      "3484AB20CFF41CC1"
+      "27ECE5B72C7498DE"
     ],
     "CAv": [
-      "35745713C6C668A3"
+      "ABA8E2973103D828"
     ],
     "DTBT": [
       "4053A5C9A5BCFDF9"
@@ -14,25 +14,25 @@
       "0"
     ],
     "Kd_shear": [
-      "E71BB97FE96DE8CC"
+      "5C156FAFB415CEDC"
     ],
     "Kv_shear": [
-      "2866D8B628AA73E1"
+      "F275A3362DE640C9"
     ],
     "Kv_shear_Bu": [
-      "762E3DB5F0CD6D9B"
+      "A9CD31104B83D672"
     ],
     "MEKE": [
-      "F282C30DD857D8C1"
+      "F282C2A693FC4C41"
     ],
     "MEKE_Kh": [
-      "ADBEC5EAD0D2743B"
+      "ADBEC5B3E1C6B4DB"
     ],
     "MEKE_Ku": [
-      "7A11342B049FDDAF"
+      "7A1133F6493DD72E"
     ],
     "MLD": [
-      "E06A01BBAA12DEEA"
+      "E08DC4EBA866A998"
     ],
     "MLD_MLE_filtered": [
       "95BC79D120A803E0"
@@ -41,61 +41,61 @@
       "A7C78F12555AF6D6"
     ],
     "MLE_Bflux": [
-      "ADB33A153F678FD2"
+      "AE3CBC952EA37600"
     ],
     "SFC_BFLX": [
-      "ACB2E2CF04EC3EFD"
+      "ACFC40FDFB79FE66"
     ],
     "Salt": [
-      "E4F179B70E0EA4C2"
+      "E4F148F312157CC9"
     ],
     "Temp": [
-      "A09A652495546C12"
+      "A014B12325FE124E"
     ],
     "age": [
-      "B669C082BB23923F"
+      "F545E1AF04636E5E"
     ],
     "ave_ssh": [
-      "E8BC2C6EE752D2A5"
+      "E8BC2C5DAB51007F"
     ],
     "diffu": [
-      "D684702C45B485F8"
+      "DC0BAD158F55F530"
     ],
     "diffv": [
-      "A1A7A94171FC8EA4"
+      "A02E3DA7E247439B"
     ],
     "frazil": [
-      "B905D36AFD5A6B0D"
+      "785CB6C66F609DD8"
     ],
     "h": [
-      "135C0748FDA3FE01"
+      "135C03ECC9FB76D6"
     ],
     "h_ML": [
-      "E06A01BBAA12DEEA"
+      "E08DC4EBA866A998"
     ],
     "p_surf_EOS": [
       "317762F5F33EBB32"
     ],
     "sfc": [
-      "DB9D5BDA1A3141C7"
+      "DBFB447A589681FB"
     ],
     "u": [
-      "86FD9D592DE68C1A"
+      "289C636E2C89B69"
     ],
     "u2": [
-      "6C9C0B4FA4D27392"
+      "6A8BAF1C1221521D"
     ],
     "ubtav": [
-      "119A5887F083420"
+      "1714718F850CACC"
     ],
     "v": [
-      "76BF098F8D9BFD"
+      "8B21D0C81B90B896"
     ],
     "v2": [
-      "232804787CB9216A"
+      "A73E2C5F0584816F"
     ],
     "vbtav": [
-      "44E4B8D77632A4FC"
+      "44EB77381B5E15C7"
     ]
   }
 }


### PR DESCRIPTION
**1. Summary**:

This build updates the component versions to MOM6 `2026.05.002`, CICE6 `CICE6.6.3-2`, and WW3 `2026.03.001`. It includes MOM6 diagnostic and numerical fixes, a CICE supergrid fix, and WW3 memory leak and floe size output fixes.

**2. Issues Addressed:**

- Add a minimum-thickness clamp in `mixedlayer_restrat_Bodner` ([MOM6 #61](https://github.com/ACCESS-NRI/MOM6/pull/61)).
- Add the `FILE_DYE_TRACER_ACCUMULATE` parameter for file-based dye tracers ([MOM6 #67](https://github.com/ACCESS-NRI/MOM6/pull/67)).
- Save the correct thickness for the `vert_remap_h` diagnostic ([MOM6 #66](https://github.com/ACCESS-NRI/MOM6/pull/66)).
- Add a numerical-mixing diagnostic ([MOM6 #57](https://github.com/ACCESS-NRI/MOM6/pull/57)).
- Fix `ANGLE` and tripole closure in the MOM supergrid ([CICE #50](https://github.com/ACCESS-NRI/CICE/pull/50)). This is answer-changing.
- Remove the `W3_IS2` compile guard from the IC5 floe-diameter update ([WW3 #15](https://github.com/ACCESS-NRI/WW3/pull/15)).
- Avoid ST6 `IRANGE` heap allocations in source loops ([WW3 #16](https://github.com/ACCESS-NRI/WW3/pull/16)).

**3. Dependencies (e.g. on payu, model or om3-scripts)**

This change requires changes to (note required version where true):
- [ ] payu:
- [x] access-om3: 2026.05.003
- [ ] om3-scripts:

**5. CI Testing**

- [x] `!test repro` or `!test repro commit` has been run

The determinism tests pass for the new build.

**6. Reproducibility**

Is this reproducible with the previous commit? (If not, why not?)
- [ ] Yes
- [x] No

The CICE supergrid fix is answer-changing

**7. Documentation**

The docs folder has been updated with output from running the model?
- [ ] Yes
- [x] N/A

A PR has been created for updating the documentation?
- [ ] Yes: <!--link-->
- [x] N/A

**8. Formatting**

Changes to MOM_input have been copied from model output in docs/MOM_parameter_docs.short?
- [ ] Yes
- [x] N/A

**9. Merge Strategy**

- [ ] Merge commit
- [ ] Rebase and merge
- [x] Squash