### PR TITLE
Heat flux diagnostics and runoff inputs

### DIFF
--- a/MOM_input
+++ b/MOM_input
@@ -801,6 +801,8 @@ SALT_RESTORE_VARIABLE = "asalt" ! default = "salt"
 SRESTORE_AS_SFLUX = True        !   [Boolean] default = False
                                 ! If true, the restoring of salinity is applied as a salt flux instead of as a
                                 ! freshwater flux.
+MAX_DELTA_SRESTORE = 0.5      !   [PSU or g kg-1] default = 999.0
+                                ! The maximum salinity difference used in restoring terms.
 USE_RIGID_SEA_ICE = True        !   [Boolean] default = False
                                 ! If true, sea-ice is rigid enough to exert a nonhydrostatic pressure that
                                 ! resist vertical motion.

--- a/config.yaml
+++ b/config.yaml
@@ -37,7 +37,7 @@ input:
     - /g/data/vk83/configurations/inputs/access-om3/share/meshes/share/2026.01.21/JRA55do-datm-ESMFmesh.nc
     - /g/data/vk83/configurations/inputs/access-om3/share/meshes/share/2026.01.21/JRA55do-drof-ESMFmesh.nc
     - /g/data/vk83/prerelease/configurations/inputs/access-om3/cmeps/remap_weights/global.100km/2026.04.07/access-om3-100km-rof-remap-weights.nc
-    - /g/data/vk83/prerelease/configurations/inputs/access-om3/cmeps/rofi_pattern/global.100km/2026.06.16/access-om3-100km-rofi-climatology.nc
+    - /g/data/vk83/prerelease/configurations/inputs/access-om3/cmeps/rofi_pattern/global.100km/2026.08.10/access-om3-100km-rofi-climatology.nc
     - /g/data/vk83/prerelease/configurations/inputs/access-om3/mom/tidal_external_files/global.100km/2026.04.07/bottom_roughness.nc
     - /g/data/vk83/prerelease/configurations/inputs/access-om3/mom/tidal_external_files/global.100km/2026.04.07/tideamp.nc
     - /g/data/vk83/prerelease/configurations/inputs/access-om3/share/grids/global.100km/2026.04.07/topog.nc

--- a/config.yaml
+++ b/config.yaml
@@ -36,7 +36,7 @@ input:
     - /g/data/vk83/prerelease/configurations/inputs/access-om3/share/meshes/global.100km/2026.04.07/access-om3-100km-nomask-ESMFmesh.nc
     - /g/data/vk83/configurations/inputs/access-om3/share/meshes/share/2026.01.21/JRA55do-datm-ESMFmesh.nc
     - /g/data/vk83/configurations/inputs/access-om3/share/meshes/share/2026.01.21/JRA55do-drof-ESMFmesh.nc
-    - /g/data/vk83/prerelease/configurations/inputs/access-om3/cmeps/remap_weights/global.100km/2026.04.07/access-om3-100km-rof-remap-weights.nc
+    - /g/data/vk83/prerelease/configurations/inputs/access-om3/cmeps/remap_weights/global.100km/2026.08.10/access-om3-100km-rof-remap-weights.nc
     - /g/data/vk83/prerelease/configurations/inputs/access-om3/cmeps/rofi_pattern/global.100km/2026.08.10/access-om3-100km-rofi-climatology.nc
     - /g/data/vk83/prerelease/configurations/inputs/access-om3/mom/tidal_external_files/global.100km/2026.04.07/bottom_roughness.nc
     - /g/data/vk83/prerelease/configurations/inputs/access-om3/mom/tidal_external_files/global.100km/2026.04.07/tideamp.nc

--- a/diag_table
+++ b/diag_table
@@ -283,3 +283,14 @@ ACCESS-OM3
 "ocean_model", "total_icemelt", "total_icemelt", "access-om3.mom6.scalar.1day.snap.%4yr", "all", "none", "none", 1
 "ocean_model", "total_frunoff", "total_frunoff", "access-om3.mom6.scalar.1day.snap.%4yr", "all", "none", "none", 1
 "ocean_model", "total_lrunoff", "total_lrunoff", "access-om3.mom6.scalar.1day.snap.%4yr", "all", "none", "none", 1
+"ocean_model", "total_hfevapds", "total_hfevapds", "access-om3.mom6.scalar.1day.snap.%4yr", "all", "none", "none", 1
+"ocean_model", "total_heat_content_massin", "total_heat_content_massin", "access-om3.mom6.scalar.1day.snap.%4yr", "all", "none", "none", 1
+"ocean_model", "total_hfds", "total_hfds", "access-om3.mom6.scalar.1day.snap.%4yr", "all", "none", "none", 1
+"ocean_model", "total_rsntds", "total_rsntds", "access-om3.mom6.scalar.1day.snap.%4yr", "all", "none", "none", 1
+"ocean_model", "total_rlntds", "total_rlntds", "access-om3.mom6.scalar.1day.snap.%4yr", "all", "none", "none", 1
+"ocean_model", "total_hflso", "total_hflso", "access-om3.mom6.scalar.1day.snap.%4yr", "all", "none", "none", 1
+"ocean_model", "total_lat_evap", "total_lat_evap", "access-om3.mom6.scalar.1day.snap.%4yr", "all", "none", "none", 1
+"ocean_model", "total_hfsnthermds", "total_hfsnthermds", "access-om3.mom6.scalar.1day.snap.%4yr", "all", "none", "none", 1
+"ocean_model", "total_hfibthermds", "total_hfibthermds", "access-om3.mom6.scalar.1day.snap.%4yr", "all", "none", "none", 1
+"ocean_model", "total_hfsso", "total_hfsso", "access-om3.mom6.scalar.1day.snap.%4yr", "all", "none", "none", 1
+"ocean_model", "total_seaice_melt_heat", "total_seaice_melt_heat", "access-om3.mom6.scalar.1day.snap.%4yr", "all", "none", "none", 1

--- a/diag_table
+++ b/diag_table
@@ -103,9 +103,6 @@ ACCESS-OM3
 "access-om3.mom6.2d.hfrainds.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
 "ocean_model", "hfrainds", "hfrainds", "access-om3.mom6.2d.hfrainds.1mon.mean.%4yr", "all", "average", "none", 2
 
-"access-om3.mom6.2d.net_heat_coupler.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
-"ocean_model", "net_heat_coupler", "net_heat_coupler", "access-om3.mom6.2d.net_heat_coupler.1mon.mean.%4yr", "all", "average", "none", 2
-
 "access-om3.mom6.2d.hfds.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
 "ocean_model", "hfds", "hfds", "access-om3.mom6.2d.hfds.1mon.mean.%4yr", "all", "average", "none", 2
 

--- a/diag_table_source.yaml
+++ b/diag_table_source.yaml
@@ -218,7 +218,6 @@ diag_table:
         fields:
             hfrunoffds: # Heat content (relative to 0C) of liquid+solid runoff into ocean
             hfrainds: # Heat content (relative to 0degC) of liquid+frozen precip entering ocean
-            net_heat_coupler: # Surface ocean heat flux from SW+LW+latent+sensible+seaice_melt_heat (via the coupler)
             hfds: # Surface ocean heat flux from SW+LW+lat+sens+mass transfer+frazil+restore+seaice_melt_heat or flux adjustments net_heat_surface
             wfo: # Net surface water flux (precip+melt+lrunoff+ice calving-evap) PRCmE
             pso: # Pressure at ice-ocean or atmosphere-ocean interface p_surf

--- a/diag_table_source.yaml
+++ b/diag_table_source.yaml
@@ -338,3 +338,14 @@ diag_table:
             total_precip: # Area integrated liquid+frozen precip into ocean
             total_frunoff: # Area integrated frozen runoff (calving) & iceberg melt into ocean
             total_lrunoff: # Area integrated liquid runoff into ocean
+            total_hfevapds: # Area integrated heat content (relative to 0C) of water leaving ocean
+            total_heat_content_massin: # Area integrated heat content (relative to 0C) of water entering ocean
+            total_hfds: # Area integrated surface heat flux from SW+LW+lat+sens+mass+frazil+restore or flux adjustments
+            total_rsntds: # Area integrated net downward shortwave at sea water surface
+            total_rlntds: # Area integrated net downward longwave at sea water surface
+            total_hflso: # Area integrated surface downward latent heat flux
+            total_lat_evap: # Area integrated latent heat flux due to evap/condense
+            total_hfsnthermds: # Area integrated latent heat flux due to melting frozen precip
+            total_hfibthermds: # Area integrated latent heat flux due to melting icebergs
+            total_hfsso: # Area integrated downward sensible heat flux
+            total_seaice_melt_heat: # Area integrated surface heat flux from snow and sea ice melt

--- a/docs/MOM_parameter_doc.all
+++ b/docs/MOM_parameter_doc.all
@@ -629,85 +629,10 @@ FATAL_INCONSISTENT_RESTART_TIME = False !   [Boolean] default = False
                                 ! If true and a time_in value is provided to MOM_initialize_state, verify that
                                 ! the time read from a restart file is the same as time_in, and issue a fatal
                                 ! error if it is not.  Otherwise, simply set the time to time_in if present.
-INIT_LAYERS_FROM_Z_FILE = True  !   [Boolean] default = False
-                                ! If true, initialize the layer thicknesses, temperatures, and salinities from a
-                                ! Z-space file on a latitude-longitude grid.
-
-! === module MOM_initialize_layers_from_Z ===
-TEMP_SALT_Z_INIT_FILE = "woa23_ts_01_mom.nc" ! default = "temp_salt_z.nc"
-                                ! The name of the z-space input file used to initialize temperatures (T) and
-                                ! salinities (S). If T and S are not in the same file, TEMP_Z_INIT_FILE and
-                                ! SALT_Z_INIT_FILE must be set.
-TEMP_Z_INIT_FILE = "woa23_ts_01_mom.nc" ! default = "woa23_ts_01_mom.nc"
-                                ! The name of the z-space input file used to initialize temperatures, only.
-SALT_Z_INIT_FILE = "woa23_ts_01_mom.nc" ! default = "woa23_ts_01_mom.nc"
-                                ! The name of the z-space input file used to initialize temperatures, only.
-Z_INIT_FILE_PTEMP_VAR = "ptemp" ! default = "ptemp"
-                                ! The name of the potential temperature variable in TEMP_Z_INIT_FILE.
-Z_INIT_FILE_SALT_VAR = "salt"   ! default = "salt"
-                                ! The name of the salinity variable in SALT_Z_INIT_FILE.
-Z_INIT_HOMOGENIZE = False       !   [Boolean] default = False
-                                ! If True, then horizontally homogenize the interpolated initial conditions.
-Z_INIT_ALE_REMAPPING = True     !   [Boolean] default = False
-                                ! If True, then remap straight to model coordinate from file.
-Z_INIT_REMAPPING_SCHEME = "PPM_IH4" ! default = "PPM_IH4"
-                                ! The remapping scheme to use if using Z_INIT_ALE_REMAPPING is True.
-Z_INIT_REMAP_GENERAL = True     !   [Boolean] default = False
-                                ! If false, only initializes to z* coordinates. If true, allows initialization
-                                ! directly to general coordinates.
-Z_INIT_REMAP_FULL_COLUMN = True !   [Boolean] default = True
-                                ! If false, only reconstructs profiles for valid data points. If true, inserts
-                                ! vanished layers below the valid data.
-Z_INIT_REMAP_OLD_ALG = False    !   [Boolean] default = False
-                                ! If false, uses the preferred remapping algorithm for initialization. If true,
-                                ! use an older, less robust algorithm for remapping.
-TEMP_SALT_INIT_VERTICAL_REMAP_ONLY = True !   [Boolean] default = False
-                                ! If true, initial conditions are on the model horizontal grid. Extrapolation
-                                ! over missing ocean values is done using an ICE-9 procedure with vertical ALE
-                                ! remapping .
 Z_INIT_REMAPPING_USE_OM4_SUBCELLS = False !   [Boolean] default = False
                                 ! If true, use the OM4 remapping-via-subcells algorithm for initialization. See
                                 ! REMAPPING_USE_OM4_SUBCELLS for more details. We recommend setting this option
                                 ! to false.
-HOR_REGRID_ANSWER_DATE = 99991231 ! default = 99991231
-                                ! The vintage of the order of arithmetic for horizontal regridding.  Dates
-                                ! before 20190101 give the same answers as the code did in late 2018, while
-                                ! later versions add parentheses for rotational symmetry.  Dates after 20230101
-                                ! use reproducing sums for global averages.
-LAND_FILL_TEMP = 0.0            !   [degC] default = 0.0
-                                ! A value to use to fill in ocean temperatures on land points.
-LAND_FILL_SALIN = 35.0          !   [ppt] default = 35.0
-                                ! A value to use to fill in ocean salinities on land points.
-HORIZ_INTERP_TOL_TEMP = 0.001   !   [degC] default = 0.001
-                                ! The tolerance in temperature changes between iterations when interpolating
-                                ! from an input dataset using horiz_interp_and_extrap_tracer.  This routine
-                                ! converges slowly, so an overly small tolerance can get expensive.
-HORIZ_INTERP_TOL_SALIN = 0.001  !   [ppt] default = 0.001
-                                ! The tolerance in salinity changes between iterations when interpolating from
-                                ! an input dataset using horiz_interp_and_extrap_tracer.  This routine converges
-                                ! slowly, so an overly small tolerance can get expensive.
-DEPRESS_INITIAL_SURFACE = False !   [Boolean] default = False
-                                ! If true,  depress the initial surface to avoid huge tsunamis when a large
-                                ! surface pressure is applied.
-TRIM_IC_FOR_P_SURF = False      !   [Boolean] default = False
-                                ! If true, cuts way the top of the column for initial conditions at the depth
-                                ! where the hydrostatic pressure matches the imposed surface pressure which is
-                                ! read from file.
-REGRID_ACCELERATE_INIT = False  !   [Boolean] default = False
-                                ! If true, runs REGRID_ACCELERATE_ITERATIONS iterations of the regridding
-                                ! algorithm to push the initial grid to be consistent with the initial
-                                ! condition. Useful only for state-based and iterative coordinates.
-VELOCITY_CONFIG = "zero"        ! default = "zero"
-                                ! A string that determines how the initial velocities are specified for a new
-                                ! run:
-                                !     file - read velocities from the file specified
-                                !       by (VELOCITY_FILE).
-                                !     zero - the fluid is initially at rest.
-                                !     uniform - the flow is uniform (determined by
-                                !       parameters INITIAL_U_CONST and INITIAL_V_CONST).
-                                !     rossby_front - a mixed layer front in thermal wind balance.
-                                !     soliton - Equatorial Rossby soliton.
-                                !     USER - call a user modified routine.
 ODA_INCUPD = False              !   [Boolean] default = False
                                 ! If true, oda incremental updates will be applied everywhere in the domain.
 SPONGE = False                  !   [Boolean] default = False
@@ -2632,7 +2557,7 @@ SALT_RESTORE_VARIABLE = "asalt" ! default = "salt"
 SRESTORE_AS_SFLUX = True        !   [Boolean] default = False
                                 ! If true, the restoring of salinity is applied as a salt flux instead of as a
                                 ! freshwater flux.
-MAX_DELTA_SRESTORE = 999.0      !   [PSU or g kg-1] default = 999.0
+MAX_DELTA_SRESTORE = 0.5        !   [PSU or g kg-1] default = 999.0
                                 ! The maximum salinity difference used in restoring terms.
 MASK_SRESTORE_UNDER_ICE = False !   [Boolean] default = False
                                 ! If true, disables SSS restoring under sea-ice based on a frazil criteria

--- a/docs/MOM_parameter_doc.short
+++ b/docs/MOM_parameter_doc.short
@@ -222,24 +222,6 @@ REMAPPING_USE_OM4_SUBCELLS = False !   [Boolean] default = True
                                 ! recommend setting this option to false.
 
 ! === module MOM_state_initialization ===
-INIT_LAYERS_FROM_Z_FILE = True  !   [Boolean] default = False
-                                ! If true, initialize the layer thicknesses, temperatures, and salinities from a
-                                ! Z-space file on a latitude-longitude grid.
-
-! === module MOM_initialize_layers_from_Z ===
-TEMP_SALT_Z_INIT_FILE = "woa23_ts_01_mom.nc" ! default = "temp_salt_z.nc"
-                                ! The name of the z-space input file used to initialize temperatures (T) and
-                                ! salinities (S). If T and S are not in the same file, TEMP_Z_INIT_FILE and
-                                ! SALT_Z_INIT_FILE must be set.
-Z_INIT_ALE_REMAPPING = True     !   [Boolean] default = False
-                                ! If True, then remap straight to model coordinate from file.
-Z_INIT_REMAP_GENERAL = True     !   [Boolean] default = False
-                                ! If false, only initializes to z* coordinates. If true, allows initialization
-                                ! directly to general coordinates.
-TEMP_SALT_INIT_VERTICAL_REMAP_ONLY = True !   [Boolean] default = False
-                                ! If true, initial conditions are on the model horizontal grid. Extrapolation
-                                ! over missing ocean values is done using an ICE-9 procedure with vertical ALE
-                                ! remapping .
 
 ! === module MOM_diag_mediator ===
 NUM_DIAG_COORDS = 2             ! default = 1
@@ -777,6 +759,8 @@ SALT_RESTORE_VARIABLE = "asalt" ! default = "salt"
 SRESTORE_AS_SFLUX = True        !   [Boolean] default = False
                                 ! If true, the restoring of salinity is applied as a salt flux instead of as a
                                 ! freshwater flux.
+MAX_DELTA_SRESTORE = 0.5        !   [PSU or g kg-1] default = 999.0
+                                ! The maximum salinity difference used in restoring terms.
 USE_RIGID_SEA_ICE = True        !   [Boolean] default = False
                                 ! If true, sea-ice is rigid enough to exert a nonhydrostatic pressure that
                                 ! resist vertical motion.

--- a/docs/available_diags.000000
+++ b/docs/available_diags.000000
@@ -4821,7 +4821,7 @@
     ! long_name: Heat content (relative to 0degC) of net mass entering ocean ocean
     ! units: W m-2
     ! cell_methods: xh:mean yh:mean area:mean
-"net_heat_coupler"  [Used]
+"net_heat_coupler"  [Unused]
     ! modules: {ocean_model,ocean_model_d2}
     ! dimensions: xh, yh
     ! long_name: Surface ocean heat flux from SW+LW+latent+sensible+seaice_melt_heat (via the coupler)
@@ -4982,7 +4982,7 @@
     ! long_name: Area integrated heat content (relative to 0C) of water leaving ocean
     ! units: W
     ! variants: {total_heat_content_massout,total_hfevapds}
-"total_heat_content_massin"  [Unused]
+"total_heat_content_massin"  [Used]
     ! modules: ocean_model
     ! dimensions: scalar
     ! long_name: Area integrated heat content (relative to 0C) of water entering ocean
@@ -5021,7 +5021,7 @@
     ! long_name: Area integrated surface downward latent heat flux
     ! units: W
     ! variants: {total_lat,total_hflso}
-"total_lat_evap"  [Unused]
+"total_lat_evap"  [Used]
     ! modules: ocean_model
     ! dimensions: scalar
     ! long_name: Area integrated latent heat flux due to evap/condense
@@ -5054,7 +5054,7 @@
     ! dimensions: scalar
     ! long_name: Area integrated surface heat flux from restoring and/or flux adjustment
     ! units: W
-"total_seaice_melt_heat"  [Unused]
+"total_seaice_melt_heat"  [Used]
     ! modules: ocean_model
     ! dimensions: scalar
     ! long_name: Area integrated surface heat flux from snow and sea ice melt

--- a/manifests/input.yaml
+++ b/manifests/input.yaml
@@ -3372,10 +3372,10 @@ work/INPUT/access-om3-100km-nomask-ESMFmesh.nc:
     binhash: 627afeda4806fee1dcb1c5d980610c94
     md5: 92f32a4f0e7e6fb2a3c977e3936b7a5b
 work/INPUT/access-om3-100km-rof-remap-weights.nc:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-om3/cmeps/remap_weights/global.100km/2026.04.07/access-om3-100km-rof-remap-weights.nc
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-om3/cmeps/remap_weights/global.100km/2026.08.10/access-om3-100km-rof-remap-weights.nc
   hashes:
-    binhash: 507072984b31ac2fdcd57e191753bfc7
-    md5: a91d74daa3fe143132ea254c4eb00f9d
+    binhash: 51b6495c65967ad56385377dc8ce009f
+    md5: 7d2565ab40accf4a90c1cc90299ca271
 work/INPUT/access-om3-100km-rofi-climatology.nc:
   fullpath: /g/data/vk83/prerelease/configurations/inputs/access-om3/cmeps/rofi_pattern/global.100km/2026.08.10/access-om3-100km-rofi-climatology.nc
   hashes:

--- a/manifests/input.yaml
+++ b/manifests/input.yaml
@@ -3377,10 +3377,10 @@ work/INPUT/access-om3-100km-rof-remap-weights.nc:
     binhash: 507072984b31ac2fdcd57e191753bfc7
     md5: a91d74daa3fe143132ea254c4eb00f9d
 work/INPUT/access-om3-100km-rofi-climatology.nc:
-  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-om3/cmeps/rofi_pattern/global.100km/2026.06.16/access-om3-100km-rofi-climatology.nc
+  fullpath: /g/data/vk83/prerelease/configurations/inputs/access-om3/cmeps/rofi_pattern/global.100km/2026.08.10/access-om3-100km-rofi-climatology.nc
   hashes:
-    binhash: 6eb1e5850e289b55c5f7e23647f5b359
-    md5: 2bff12fda2c10976461507bc5ae0c7fa
+    binhash: 2692d28c89de8a4151b7ff322c720792
+    md5: 8e7c5bb8e9659594a769b701194c813c
 work/INPUT/bottom_roughness.nc:
   fullpath: /g/data/vk83/prerelease/configurations/inputs/access-om3/mom/tidal_external_files/global.100km/2026.04.07/bottom_roughness.nc
   hashes:

--- a/testing/checksum/historical-6hr-checksum.json
+++ b/testing/checksum/historical-6hr-checksum.json
@@ -2,100 +2,100 @@
   "schema_version": "1-0-0",
   "output": {
     "CAu": [
-      "1C9A3DD7E98C2B52"
+      "52175625667DE26F"
     ],
     "CAv": [
-      "EEDED65DDDE19B1"
+      "659A2DEDF5D49F54"
     ],
     "DTBT": [
-      "4053A5C9A68F8B34"
+      "4053A5C9A6967E0B"
     ],
     "First_direction": [
       "0"
     ],
     "Kd_shear": [
-      "914AB6123E74A8ED"
+      "67D2C21453E2EFCD"
     ],
     "Kv_shear": [
-      "4F27A0103CCDC887"
+      "92C06FC9D894B44D"
     ],
     "Kv_shear_Bu": [
-      "4B9B0B41C006A8F"
+      "1E942E3648664D3D"
     ],
     "MEKE": [
-      "EDE902462A06D6E7"
+      "EE6965B2729FBF4E"
     ],
     "MEKE_Kh": [
-      "A2FD0AF928A8C0D1"
+      "9FE7ABB44ED7A490"
     ],
     "MEKE_Ku": [
-      "6FB6FE3D3B30A3F4"
+      "6C7CF38FC2F0F9ED"
     ],
     "MLD": [
-      "23F2D81187F4A86B"
+      "228B6FCD873AE275"
     ],
     "MLD_MLE_filtered": [
-      "926B81AE4AD01647"
+      "926678654B271645"
     ],
     "MLD_MLE_filtered_slow": [
-      "A2BC782A422E5281"
+      "A2BB1FF0CBC5F7DC"
     ],
     "MLE_Bflux": [
-      "7E821D6B40175598"
+      "7D8C383E72CF89F9"
     ],
     "SFC_BFLX": [
-      "DC4CFBE7A808C059"
+      "56066F1D77DB5B7A"
     ],
     "Salt": [
-      "E925F1A86AD77A93"
+      "E98841574052B991"
     ],
     "Temp": [
-      "3AD33ABD092E576C"
+      "3EACD7449D8F0037"
     ],
     "age": [
-      "8A49CE41D30D1B65"
+      "C6DEEF984C3A812F"
     ],
     "ave_ssh": [
-      "871AC82FDBB005B3"
+      "871A937CCF7698FD"
     ],
     "diffu": [
-      "FD3D76812131C780"
+      "7046798D420D252D"
     ],
     "diffv": [
-      "6DE167B7639E0F7"
+      "C6688DBA6F58C962"
     ],
     "frazil": [
-      "ACCFF41D053F68C"
+      "C996CDCF4252D7EA"
     ],
     "h": [
-      "B0DF366295514724"
+      "B0D91781875052C7"
     ],
     "h_ML": [
-      "23F2D81187F4A86B"
+      "228B6FCD873AE275"
     ],
     "p_surf_EOS": [
       "317762F5F33EBB32"
     ],
     "sfc": [
-      "7A47C9649252E460"
+      "7ABA29CF983E6D76"
     ],
     "u": [
-      "BD4AC33230DBD3DF"
+      "BA832716E981BA93"
     ],
     "u2": [
-      "30A8E03AF0D789A7"
+      "A639D6F11961E947"
     ],
     "ubtav": [
-      "1C5057D17CFBE66"
+      "81EE913C3D65A8FF"
     ],
     "v": [
-      "74B25FC0D4580D6"
+      "1733B6F55C4879C4"
     ],
     "v2": [
-      "8590DE106A5A0E89"
+      "A35C0AF307D71B4"
     ],
     "vbtav": [
-      "46987C62570608B0"
+      "46B789D5477230FB"
     ]
   }
 }


### PR DESCRIPTION
**1. Summary**:

Removes a redundant heat diagnostic and adds heat-budget scalar diagnostics, updates the runoff/iceberg remapping inputs, and caps the salinity restoring flux.

- Removed `net_heat_coupler` from `diag_table` — it was nearly identical to `hfds`/`net_heat_surface`, differing only by missing `masstransfer`+`frazil` (#1500).
- Added global-scalar (area-integrated) heat diagnostics (#1500).
- Updated the runoff remap weights and to spread large rivers (#396, #1465).
- Updated the iceberg/calving climatology (`access-om3-100km-rofi-climatology.nc`) (#404).
- Added `MAX_DELTA_SRESTORE = 0.5` to `MOM_input` to cap the salinity restoring flux.

**2. Issues Addressed:**
- #1500
- #396
- #1465
- #404

**3. AI Tooling**

Was used to write this description, and to prepare some changes to the iceberg prep script in om3-scripts

**4. Dependencies (e.g. on payu, model or om3-scripts)**

This change requires changes to (note required version where true):
- [ ] payu:
- [ ] access-om3:
- [x] om3-scripts: https://github.com/ACCESS-NRI/om3-scripts/tree/9c13690ba7700504e77f92dc4a6f9e63e971835d

**5. Ad-hoc Testing**

Ran for 23 years (JRA55do IAF) with no crashes. Output archived at `/g/data/tm70/as2285/payu/om3-heat_diags/100km_test/archive`.

**6. CI Testing**
- [ ] `!test repro` or `!test repro commit ` has been run

**7. Reproducibility**

Is this reproducible with the previous commit? (If not, why not?)
- [ ] Yes
- [x] No (remap weights, climatology, and `MAX_DELTA_SRESTORE` all change model answers)

**8. Documentation**

The docs folder has been updated with output from running the model?
- [x] Yes

**9. Formatting**

Changes to MOM_input have been copied from model output in docs/MOM_parameter_docs.short?
- [x] Yes

**10. Merge Strategy**
- [x] Merge commit
- [ ] Rebase and merge
- [ ] Squash