### PR TITLE
(Manual) Auto update dev-MC_panan4km_jra_ryf to use access-om3/pr245-8

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -9,19 +9,19 @@
 # Using payu sync is recommend to copy data from ephemeral scratch space to 
 # longer term storage
 sync:
-    enable: False   # set path below and change to true
-    base_path: null # Set to location on /g/data (e.g. /g/data/PROJECT/USER/)
-    restarts: True
-    exclude_uncollated: False
+  enable: false     # set path below and change to true
+  base_path: null   # Set to location on /g/data (e.g. /g/data/PROJECT/USER/)
+  restarts: true
+  exclude_uncollated: false
 
 #Model software version
 modules:
-    use:
-        - /g/data/vk83/modules
-    load:
-        - access-om3/2026.05.002
-        - model-tools/mppnccombine-fast/2025.07.000
-
+  use:
+  - /g/data/vk83/modules
+  - /g/data/vk83/prerelease/modules
+  load:
+  - access-om3/pr245-8
+  - model-tools/mppnccombine-fast/2025.07.000
 queue: normalsr
 ncpus: 1664
 jobfs: 10GB
@@ -32,32 +32,32 @@ jobname: 4km_panAn_om3
 model: access-om3
 exe: access-om3-MOM6-CICE6
 input:
-    - /g/data/vk83/prerelease/configurations/inputs/access-om3/panan.4km/2026.01.08/kmt.nc
-    - /g/data/vk83/prerelease/configurations/inputs/access-om3/panan.4km/2026.01.08/ocean_hgrid.nc
-    - /g/data/vk83/prerelease/configurations/inputs/access-om3/panan.4km/2026.01.08/ocean_vgrid.nc
-    - /g/data/vk83/prerelease/configurations/inputs/access-om3/panan.4km/2026.01.08/ocean_temp_salt.res.nc
-    - /g/data/vk83/prerelease/configurations/inputs/access-om3/panan.4km/2026.01.08/salt_sfc_restore.nc
-    - /g/data/vk83/prerelease/configurations/inputs/access-om3/panan.4km/2026.02.27/bottom_roughness.nc
-    - /g/data/vk83/prerelease/configurations/inputs/access-om3/panan.4km/2026.01.08/tideamp.nc
-    - /g/data/vk83/prerelease/configurations/inputs/access-om3/panan.4km/2026.01.08/topog.nc
-    - /g/data/vk83/prerelease/configurations/inputs/access-om3/panan.4km/2026.06.17/chl_globcolour_monthly_clim.nc
-    - /g/data/vk83/prerelease/configurations/inputs/access-om3/panan.4km/2026.01.08/access-om3-4km-ESMFmesh.nc
-    - /g/data/vk83/prerelease/configurations/inputs/access-om3/panan.4km/2026.01.08/access-om3-4km-nomask-ESMFmesh.nc
-    - /g/data/vk83/configurations/inputs/access-om3/share/meshes/share/2026.01.21/JRA55do-datm-ESMFmesh.nc
-    - /g/data/vk83/configurations/inputs/access-om3/share/meshes/share/2026.01.21/JRA55do-drof-ESMFmesh.nc
-    - /g/data/vk83/prerelease/configurations/inputs/access-om3/cmeps/remap_weights/panan.4km/2026.06.26/access-om3-panan4km-rof-remap-weights.nc
-    - /g/data/vk83/prerelease/configurations/inputs/access-om3/cmeps/rofi_pattern/panan.4km/2026.06.26/access-om3-panan4km-rofi-climatology.nc
-    - /g/data/vk83/configurations/inputs/JRA-55/RYF/v1-6/2026.04.15
-    - /g/data/vk83/prerelease/configurations/inputs/access-om3/panan.4km/2026.01.08/OBC37S_forcing_access_yr2_4km.nc
-    - /g/data/vk83/prerelease/configurations/inputs/access-om3/panan.4km/2026.01.08/diag_rho2.nc
+- /g/data/vk83/prerelease/configurations/inputs/access-om3/panan.4km/2026.01.08/kmt.nc
+- /g/data/vk83/prerelease/configurations/inputs/access-om3/panan.4km/2026.01.08/ocean_hgrid.nc
+- /g/data/vk83/prerelease/configurations/inputs/access-om3/panan.4km/2026.01.08/ocean_vgrid.nc
+- /g/data/vk83/prerelease/configurations/inputs/access-om3/panan.4km/2026.01.08/ocean_temp_salt.res.nc
+- /g/data/vk83/prerelease/configurations/inputs/access-om3/panan.4km/2026.01.08/salt_sfc_restore.nc
+- /g/data/vk83/prerelease/configurations/inputs/access-om3/panan.4km/2026.02.27/bottom_roughness.nc
+- /g/data/vk83/prerelease/configurations/inputs/access-om3/panan.4km/2026.01.08/tideamp.nc
+- /g/data/vk83/prerelease/configurations/inputs/access-om3/panan.4km/2026.01.08/topog.nc
+- /g/data/vk83/prerelease/configurations/inputs/access-om3/panan.4km/2026.06.17/chl_globcolour_monthly_clim.nc
+- /g/data/vk83/prerelease/configurations/inputs/access-om3/panan.4km/2026.01.08/access-om3-4km-ESMFmesh.nc
+- /g/data/vk83/prerelease/configurations/inputs/access-om3/panan.4km/2026.01.08/access-om3-4km-nomask-ESMFmesh.nc
+- /g/data/vk83/configurations/inputs/access-om3/share/meshes/share/2026.01.21/JRA55do-datm-ESMFmesh.nc
+- /g/data/vk83/configurations/inputs/access-om3/share/meshes/share/2026.01.21/JRA55do-drof-ESMFmesh.nc
+- /g/data/vk83/prerelease/configurations/inputs/access-om3/cmeps/remap_weights/panan.4km/2026.06.26/access-om3-panan4km-rof-remap-weights.nc
+- /g/data/vk83/prerelease/configurations/inputs/access-om3/cmeps/rofi_pattern/panan.4km/2026.06.26/access-om3-panan4km-rofi-climatology.nc
+- /g/data/vk83/configurations/inputs/JRA-55/RYF/v1-6/2026.04.15
+- /g/data/vk83/prerelease/configurations/inputs/access-om3/panan.4km/2026.01.08/OBC37S_forcing_access_yr2_4km.nc
+- /g/data/vk83/prerelease/configurations/inputs/access-om3/panan.4km/2026.01.08/diag_rho2.nc
 
 runlog: true
-metadata: 
-    enable: true
+metadata:
+  enable: true
 manifest:
   reproduce:
-    exe: True
-    input: True
+    exe: false
+    input: true
 
 mpi:
   flags:
@@ -73,7 +73,7 @@ collate:
   exe: mppnccombine-fast
 
 userscripts:
-    archive: /usr/bin/bash /g/data/vk83/apps/om3-scripts/payu_config/archive.sh
+  archive: /usr/bin/bash /g/data/vk83/apps/om3-scripts/payu_config/archive.sh
 
 postscript: -v PROJECT,SCRIPTS_DIR=/g/data/vk83/apps/om3-scripts -lstorage=${PBS_NCI_STORAGE}+gdata/xp65 /g/data/vk83/apps/om3-scripts/payu_config/postscript.sh
 


### PR DESCRIPTION
Manual recreation of auto-generated PR to update dev-MC_panan4km_jra_ryf to use access-om3/pr245-8 from https://github.com/ACCESS-NRI/ACCESS-OM3/pull/245

The original PR was closed and then reopened, which confused the workflow. It created a branch with the same name as the previously deleted one and did `!test repro` in the [original, closed PR](https://github.com/ACCESS-NRI/access-om3-configs/pull/1456). Opening this for clarity